### PR TITLE
integrate kinesis firehose endpoint by adding support for SubscriptionRoleArn attribute 

### DIFF
--- a/aws-sns-subscription/aws-sns-subscription.json
+++ b/aws-sns-subscription/aws-sns-subscription.json
@@ -30,7 +30,8 @@
                 "sms",
                 "sqs",
                 "Endpoint Arn for mobile app and device",
-                "lambda"
+                "lambda",
+                "firehose"
             ]
         },
         "RawMessageDelivery": {
@@ -39,6 +40,10 @@
         },
         "Region": {
             "description": "For cross-region subscriptions, the region in which the topic resides. If no region is specified, CloudFormation uses the region of the caller as the default.",
+            "type": "string"
+        },
+        "SubscriptionRoleArn": {
+            "description": "The ARN of the IAM role that has the permission to write to the Amazon Kinesis Data Firehose delivery stream and has Amazon SNS listed as a trusted entity.",
             "type": "string"
         },
         "TopicArn": {
@@ -75,7 +80,10 @@
             "permissions": [
                 "sns:Subscribe",
                 "sns:GetSubscriptionAttributes",
-                "sns:GetTopicAttributes"
+                "sns:GetTopicAttributes",
+                "iam:GetRole",
+                "iam:PassRole",
+                "iam:PutRolePolicy"
             ]
         },
         "read": {
@@ -88,14 +96,20 @@
             "permissions": [
                 "sns:SetSubscriptionAttributes",
                 "sns:GetSubscriptionAttributes",
-                "sns:GetTopicAttributes"
+                "sns:GetTopicAttributes",
+                "iam:GetRole",
+                "iam:PassRole",
+                "iam:PutRolePolicy",
+                "iam:UpdateRole"
             ]
         },
         "delete": {
             "permissions": [
                 "sns:GetSubscriptionAttributes",
                 "sns:GetTopicAttributes",
-                "sns:Unsubscribe"
+                "sns:Unsubscribe",
+                "iam:DeleteRolePolicy",
+                "iam:DetachRolePolicy"
             ]
         },
         "list": {

--- a/aws-sns-subscription/docs/README.md
+++ b/aws-sns-subscription/docs/README.md
@@ -18,6 +18,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#protocol" title="Protocol">Protocol</a>" : <i>String</i>,
         "<a href="#rawmessagedelivery" title="RawMessageDelivery">RawMessageDelivery</a>" : <i>Boolean</i>,
         "<a href="#region" title="Region">Region</a>" : <i>String</i>,
+        "<a href="#subscriptionrolearn" title="SubscriptionRoleArn">SubscriptionRoleArn</a>" : <i>String</i>,
         "<a href="#topicarn" title="TopicArn">TopicArn</a>" : <i>String</i>,
         "<a href="#filterpolicy" title="FilterPolicy">FilterPolicy</a>" : <i>Map</i>,
         "<a href="#redrivepolicy" title="RedrivePolicy">RedrivePolicy</a>" : <i>Map</i>
@@ -36,6 +37,7 @@ Properties:
     <a href="#protocol" title="Protocol">Protocol</a>: <i>String</i>
     <a href="#rawmessagedelivery" title="RawMessageDelivery">RawMessageDelivery</a>: <i>Boolean</i>
     <a href="#region" title="Region">Region</a>: <i>String</i>
+    <a href="#subscriptionrolearn" title="SubscriptionRoleArn">SubscriptionRoleArn</a>: <i>String</i>
     <a href="#topicarn" title="TopicArn">TopicArn</a>: <i>String</i>
     <a href="#filterpolicy" title="FilterPolicy">FilterPolicy</a>: <i>Map</i>
     <a href="#redrivepolicy" title="RedrivePolicy">RedrivePolicy</a>: <i>Map</i>
@@ -96,6 +98,16 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 #### Region
 
 For cross-region subscriptions, the region in which the topic resides. If no region is specified, CloudFormation uses the region of the caller as the default.
+
+_Required_: No
+
+_Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### SubscriptionRoleArn
+
+The ARN of the IAM role that has the permission to write to the Amazon Kinesis Data Firehose delivery stream and has Amazon SNS listed as a trusted entity.
 
 _Required_: No
 

--- a/aws-sns-subscription/resource-role.yaml
+++ b/aws-sns-subscription/resource-role.yaml
@@ -23,6 +23,12 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
+                - "iam:DeleteRolePolicy"
+                - "iam:DetachRolePolicy"
+                - "iam:GetRole"
+                - "iam:PassRole"
+                - "iam:PutRolePolicy"
+                - "iam:UpdateRole"
                 - "sns:GetSubscriptionAttributes"
                 - "sns:GetTopicAttributes"
                 - "sns:ListSubscriptionsByTopic"

--- a/aws-sns-subscription/src/main/java/software/amazon/sns/subscription/BaseHandlerStd.java
+++ b/aws-sns-subscription/src/main/java/software/amazon/sns/subscription/BaseHandlerStd.java
@@ -91,10 +91,14 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     final GetSubscriptionAttributesResponse getSubscriptionAttributesResponse;
 
     try {
-      getSubscriptionAttributesResponse = proxyClient.injectCredentialsAndInvokeV2(getSubscriptionAttributesRequest, proxyClient.client()::getSubscriptionAttributes);
-      if (!getSubscriptionAttributesResponse.hasAttributes()) {
-        throw new CfnNotFoundException(new Exception(String.format("Subscription %s does not exist.", getSubscriptionAttributesRequest.subscriptionArn())));
-      }
+        if (getSubscriptionAttributesRequest.subscriptionArn() == null) {
+            throw new CfnNotFoundException(new Exception("Subscription is null"));
+        }
+
+        getSubscriptionAttributesResponse = proxyClient.injectCredentialsAndInvokeV2(getSubscriptionAttributesRequest, proxyClient.client()::getSubscriptionAttributes);
+        if (!getSubscriptionAttributesResponse.hasAttributes()) {
+            throw new CfnNotFoundException(new Exception(String.format("Subscription %s does not exist.", getSubscriptionAttributesRequest.subscriptionArn())));
+        }
     } catch (final SubscriptionLimitExceededException e) {
         throw new CfnServiceLimitExceededException(e);
     } catch (final FilterPolicyLimitExceededException e) {

--- a/aws-sns-subscription/src/main/java/software/amazon/sns/subscription/Definitions.java
+++ b/aws-sns-subscription/src/main/java/software/amazon/sns/subscription/Definitions.java
@@ -11,4 +11,5 @@ public  class Definitions {
     public static String subscriptionArn = "SubscriptionArn";
     public static String pendingConfirmation = "PendingConfirmation";
     public static String subscriptionNotPending = "false";
+    public static String subscriptionRoleArn = "SubscriptionRoleArn";
 }

--- a/aws-sns-subscription/src/main/java/software/amazon/sns/subscription/SnsSubscriptionUtils.java
+++ b/aws-sns-subscription/src/main/java/software/amazon/sns/subscription/SnsSubscriptionUtils.java
@@ -7,7 +7,6 @@ import com.google.common.collect.Maps;
 import org.apache.commons.lang3.StringUtils;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 
-import java.io.IOException;
 import java.util.Map;
 
 public final class SnsSubscriptionUtils {
@@ -42,20 +41,12 @@ public final class SnsSubscriptionUtils {
     }
 
     public static Map<String,String> getAttributesForUpdate(final SubscriptionAttribute subscriptionAttribute, final Map<String, Object> previousPolicy, final Map<String, Object> desiredPolicy) {
-        final Map<String,String> attributeMap = Maps.newHashMap();
-
-        putIfChanged(attributeMap, subscriptionAttribute, convertJsonObjectToString(previousPolicy), convertJsonObjectToString(desiredPolicy));
-
-        return attributeMap;
+        return getAttributesForUpdate(subscriptionAttribute, convertJsonObjectToString(previousPolicy), convertJsonObjectToString(desiredPolicy));
     }
 
-    public static Map<String,String> getAttributesForUpdate(final SubscriptionAttribute subscriptionAttribute, final Boolean previousValue, final Boolean desiredValue) {
+    public static Map<String, String> getAttributesForUpdate(SubscriptionAttribute subscriptionAttribute, String previousValue, String desiredValue) {
         final Map<String,String> attributeMap = Maps.newHashMap();
-
-        String previousVal = previousValue != null ? Boolean.toString(previousValue) : Boolean.FALSE.toString();
-        String currentVal = desiredValue != null ? Boolean.toString(desiredValue) : Boolean.FALSE.toString();
-        putIfChanged(attributeMap, subscriptionAttribute, previousVal , currentVal);
-
+        putIfChanged(attributeMap, subscriptionAttribute, previousValue , desiredValue);
         return attributeMap;
     }
 
@@ -66,12 +57,13 @@ public final class SnsSubscriptionUtils {
         putIfNotEmpty(attributeMap, SubscriptionAttribute.FilterPolicy,  convertJsonObjectToString(currentmodel.getFilterPolicy()));
         putIfNotEmpty(attributeMap, SubscriptionAttribute.RawMessageDelivery, currentmodel.getRawMessageDelivery() != null ? Boolean.toString(currentmodel.getRawMessageDelivery()) : "");
         putIfNotEmpty(attributeMap, SubscriptionAttribute.RedrivePolicy,  convertJsonObjectToString(currentmodel.getRedrivePolicy()));
+        putIfNotEmpty(attributeMap, SubscriptionAttribute.SubscriptionRoleArn,  currentmodel.getSubscriptionRoleArn());
 
         return attributeMap;
     }
 
     private static void putIfNotEmpty(final Map<String,String> attributeMap, final SubscriptionAttribute key, final String val) {
-        if (!val.isEmpty()) {
+        if (!StringUtils.isEmpty(val)) {
             attributeMap.put(key.name(), val);
         }
     }

--- a/aws-sns-subscription/src/main/java/software/amazon/sns/subscription/SubscriptionAttribute.java
+++ b/aws-sns-subscription/src/main/java/software/amazon/sns/subscription/SubscriptionAttribute.java
@@ -4,5 +4,6 @@ public enum SubscriptionAttribute {
     DeliveryPolicy,
     FilterPolicy,
     RawMessageDelivery,
-    RedrivePolicy
+    RedrivePolicy,
+    SubscriptionRoleArn
 }

--- a/aws-sns-subscription/src/test/java/software/amazon/sns/subscription/CreateHandlerTest.java
+++ b/aws-sns-subscription/src/test/java/software/amazon/sns/subscription/CreateHandlerTest.java
@@ -1,40 +1,28 @@
 package software.amazon.sns.subscription;
 
-import java.time.Duration;
-import software.amazon.awssdk.services.sns.SnsClient;
-import software.amazon.awssdk.services.sns.model.*;
-
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.OperationStatus;
-import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.cloudformation.proxy.ProxyClient;
-import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-import software.amazon.cloudformation.exceptions.CfnNotFoundException;
-import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
-import software.amazon.cloudformation.exceptions.CfnInternalFailureException;
-
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.*;
+import software.amazon.cloudformation.exceptions.CfnInternalFailureException;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
+import software.amazon.cloudformation.exceptions.CfnNotFoundException;
+import software.amazon.cloudformation.proxy.*;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.never;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import java.util.HashMap;
-import java.util.Map;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateHandlerTest extends AbstractTestBase {
@@ -139,7 +127,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         when(proxyClient.client().getTopicAttributes(any(GetTopicAttributesRequest.class))).thenReturn(getTopicAttributesResponse);
 
 
-        final SubscribeResponse subscribeResponse = SubscribeResponse.builder().subscriptionArn("testarn").build();;
+        final SubscribeResponse subscribeResponse = SubscribeResponse.builder().subscriptionArn("testarn").build();
         when(proxyClient.client().subscribe(any(SubscribeRequest.class))).thenReturn(subscribeResponse);
 
         final Map<String, String> attributes = new HashMap<>();
@@ -176,7 +164,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         // create and read invocations
         verify(proxyClient.client(), times(2)).getTopicAttributes(any(GetTopicAttributesRequest.class));
-        verify(proxyClient.client()).getSubscriptionAttributes(any(GetSubscriptionAttributesRequest.class));
+        verify(proxyClient.client(), times(2)).getSubscriptionAttributes(any(GetSubscriptionAttributesRequest.class));
 
     }
 
@@ -194,7 +182,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         when(proxyClient.client().getTopicAttributes(any(GetTopicAttributesRequest.class))).thenReturn(getTopicAttributesResponse);
 
 
-        final SubscribeResponse subscribeResponse = SubscribeResponse.builder().subscriptionArn("testarn").build();;
+        final SubscribeResponse subscribeResponse = SubscribeResponse.builder().subscriptionArn("testarn").build();
         when(proxyClient.client().subscribe(any(SubscribeRequest.class))).thenReturn(subscribeResponse);
 
         final Map<String, String> attributes = new HashMap<>();
@@ -230,7 +218,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         // create and read invocations
         verify(proxyClient.client(), times(2)).getTopicAttributes(any(GetTopicAttributesRequest.class));
-        verify(proxyClient.client()).getSubscriptionAttributes(any(GetSubscriptionAttributesRequest.class));
+        verify(proxyClient.client(), times(2)).getSubscriptionAttributes(any(GetSubscriptionAttributesRequest.class));
 
     }
 
@@ -245,7 +233,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         when(proxyClient.client().getTopicAttributes(any(GetTopicAttributesRequest.class))).thenReturn(getTopicAttributesResponse);
 
-        final SubscribeResponse subscribeResponse = SubscribeResponse.builder().subscriptionArn("testarn").build();;
+        final SubscribeResponse subscribeResponse = SubscribeResponse.builder().subscriptionArn("testarn").build();
         when(proxyClient.client().subscribe(any(SubscribeRequest.class))).thenThrow(InvalidParameterException.class);
 
         final Map<String, String> attributes = new HashMap<>();
@@ -264,7 +252,7 @@ public class CreateHandlerTest extends AbstractTestBase {
                                                                 .desiredResourceState(model)
                                                                 .build();
 
-        assertThrows(CfnInvalidRequestException.class, () -> {handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);});
+        assertThrows(CfnInvalidRequestException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
 
 
         verify(proxyClient.client()).subscribe(any(SubscribeRequest.class));
@@ -280,7 +268,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         when(proxyClient.client().getTopicAttributes(any(GetTopicAttributesRequest.class))).thenReturn(getTopicAttributesResponse);
 
-        final SubscribeResponse subscribeResponse = SubscribeResponse.builder().subscriptionArn("testarn").build();;
+        final SubscribeResponse subscribeResponse = SubscribeResponse.builder().subscriptionArn("testarn").build();
         when(proxyClient.client().subscribe(any(SubscribeRequest.class))).thenThrow(InternalErrorException.class);
 
         final Map<String, String> attributes = new HashMap<>();
@@ -299,7 +287,7 @@ public class CreateHandlerTest extends AbstractTestBase {
                                                                 .desiredResourceState(model)
                                                                 .build();
 
-        assertThrows(CfnInternalFailureException.class, () -> {handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);});
+        assertThrows(CfnInternalFailureException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
 
 
         verify(proxyClient.client()).subscribe(any(SubscribeRequest.class));
@@ -309,8 +297,6 @@ public class CreateHandlerTest extends AbstractTestBase {
     @Test
     public void handleRequest_TopicArnDoesNotExist()  {
 
-        final Map<String, String> topicAttributes = new HashMap<>();
-
         when(proxyClient.client().getTopicAttributes(any(GetTopicAttributesRequest.class))).thenThrow(NotFoundException.class);
 
 
@@ -318,11 +304,73 @@ public class CreateHandlerTest extends AbstractTestBase {
                                                                 .desiredResourceState(model)
                                                                 .build();
 
-        assertThrows(CfnNotFoundException.class, () -> {handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);});
+        assertThrows(CfnNotFoundException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
 
         verify(proxyClient.client()).getTopicAttributes(any(GetTopicAttributesRequest.class));
         verify(proxyClient.client(), never()).unsubscribe(any(UnsubscribeRequest.class));
         verify(proxyClient.client(), never()).getSubscriptionAttributes(any(GetSubscriptionAttributesRequest.class));
+
+    }
+
+    @Test
+    public void handleRequest_Success_SubscriptionRoleArn() {
+
+        final String FIREHOSE_PROTOCOL = "firehose";
+        final String DELIVERY_STREAM_ARN = "deliverStreamArn";
+        final String TOPIC_ARN = "topicarn";
+        final String SUBSCRIPTION_ARN = "testarn";
+        final String SUBSCRIPTION_ROLE_ARN = "subscription-role-arn";
+        final Map<String, String> topicAttributes = new HashMap<>();
+        topicAttributes.put("TopicArn",TOPIC_ARN);
+
+        final GetTopicAttributesResponse getTopicAttributesResponse = GetTopicAttributesResponse.builder().attributes(topicAttributes).build();
+
+        when(proxyClient.client().getTopicAttributes(any(GetTopicAttributesRequest.class))).thenReturn(getTopicAttributesResponse);
+
+
+        final SubscribeResponse subscribeResponse = SubscribeResponse.builder().subscriptionArn(SUBSCRIPTION_ARN).build();
+        when(proxyClient.client().subscribe(any(SubscribeRequest.class))).thenReturn(subscribeResponse);
+
+        final Map<String, String> attributes = new HashMap<>();
+
+        attributes.put("SubscriptionArn", subscribeResponse.subscriptionArn());
+        attributes.put("TopicArn", TOPIC_ARN);
+        attributes.put("Protocol", FIREHOSE_PROTOCOL);
+        attributes.put("Endpoint", DELIVERY_STREAM_ARN);
+        attributes.put("SubscriptionRoleArn", SUBSCRIPTION_ROLE_ARN);
+
+        final GetSubscriptionAttributesResponse getSubscriptionResponse = GetSubscriptionAttributesResponse.builder().attributes(attributes).build();
+        when(proxyClient.client().getSubscriptionAttributes(any(GetSubscriptionAttributesRequest.class))).thenReturn(getSubscriptionResponse);
+
+        ResourceModel desiredModel = ResourceModel.builder()
+                .protocol(FIREHOSE_PROTOCOL)
+                .endpoint(DELIVERY_STREAM_ARN)
+                .topicArn(TOPIC_ARN)
+                .subscriptionArn(SUBSCRIPTION_ARN)
+                .subscriptionRoleArn(SUBSCRIPTION_ROLE_ARN)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(desiredModel)
+                .build();
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        assertThat(response).isNotNull();
+
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+
+
+        verify(proxyClient.client()).subscribe(any(SubscribeRequest.class));
+
+        // create and read invocations
+        verify(proxyClient.client(), times(2)).getTopicAttributes(any(GetTopicAttributesRequest.class));
+        verify(proxyClient.client(), times(2)).getSubscriptionAttributes(any(GetSubscriptionAttributesRequest.class));
 
     }
 }

--- a/aws-sns-subscription/src/test/java/software/amazon/sns/subscription/ReadHandlerTest.java
+++ b/aws-sns-subscription/src/test/java/software/amazon/sns/subscription/ReadHandlerTest.java
@@ -1,35 +1,26 @@
 package software.amazon.sns.subscription;
 
-import java.time.Duration;
-import software.amazon.awssdk.services.sns.SnsClient;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.OperationStatus;
-import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.cloudformation.proxy.ProxyClient;
-import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-import software.amazon.cloudformation.exceptions.CfnNotFoundException;
-import software.amazon.awssdk.services.sns.*;
-import software.amazon.awssdk.services.sns.model.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.*;
+import software.amazon.cloudformation.exceptions.CfnNotFoundException;
+import software.amazon.cloudformation.proxy.*;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-import java.util.*;
+import static org.mockito.Mockito.*;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -139,7 +130,7 @@ public class ReadHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client()).getTopicAttributes(any(GetTopicAttributesRequest.class));
-        verify(proxyClient.client()).getSubscriptionAttributes(any(GetSubscriptionAttributesRequest.class));
+        verify(proxyClient.client(), times(2)).getSubscriptionAttributes(any(GetSubscriptionAttributesRequest.class));
 
     }
 
@@ -214,7 +205,7 @@ public class ReadHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client()).getTopicAttributes(any(GetTopicAttributesRequest.class));
-        verify(proxyClient.client()).getSubscriptionAttributes(any(GetSubscriptionAttributesRequest.class));
+        verify(proxyClient.client(), times(2)).getSubscriptionAttributes(any(GetSubscriptionAttributesRequest.class));
 
     }
 

--- a/aws-sns-topic/aws-sns-topic.json
+++ b/aws-sns-topic/aws-sns-topic.json
@@ -80,7 +80,8 @@
                         "sms",
                         "sqs",
                         "application",
-                        "lambda"
+                        "lambda",
+                        "firehose"
                     ]
                 }
             },


### PR DESCRIPTION
integrate kinesis firehose endpoint by adding support for SubscriptionRoleArn attribute 

*Issue #, if available:* #16 

*Description of changes:*
- add support for SubscriptionRoleArn attribute in schema 
- parsing in create handler 
- update handler 
- unit tests 
- clean up & some refactoring 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
