### PR TITLE
resolve duplicate topic tags

### DIFF
--- a/aws-sns-topic/pom.xml
+++ b/aws-sns-topic/pom.xml
@@ -155,7 +155,6 @@
                         <exclude>**/BaseHandler*</exclude>
                         <exclude>**/HandlerWrapper*</exclude>
                         <exclude>**/ResourceModel*</exclude>
-                        <exclude>**/Configuration*</exclude>
                         <exclude>**/ClientBuilder*</exclude>
                     </excludes>
                 </configuration>

--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/Configuration.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/Configuration.java
@@ -15,6 +15,6 @@ class Configuration extends BaseConfiguration {
     public Map<String, String> resourceDefinedTags(ResourceModel resourceModel) {
         return Optional.ofNullable(resourceModel.getTags()).orElse(Collections.emptySet())
                 .stream()
-                .collect(Collectors.toMap(tag -> tag.getKey(), tag -> tag.getValue()));
+                .collect(Collectors.toMap(Tag::getKey, Tag::getValue, (value1, value2) -> value2));
     }
 }

--- a/aws-sns-topic/src/test/java/software/amazon/sns/topic/ConfigurationTest.java
+++ b/aws-sns-topic/src/test/java/software/amazon/sns/topic/ConfigurationTest.java
@@ -1,0 +1,25 @@
+package software.amazon.sns.topic;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ConfigurationTest {
+
+    @Test
+    public void testMergeDuplicateKeys() {
+        final ResourceModel model = ResourceModel.builder()
+                .tags(ImmutableSet.of(new Tag("sameKey", "value1"), new Tag("sameKey", "value2")))
+                .build();
+
+        final Configuration configuration = new Configuration();
+
+        final Map<String, String> tags = configuration.resourceDefinedTags(model);
+
+        assertEquals(ImmutableMap.of("sameKey", "value2"), tags);
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR resolves the duplicate tags if same tags with different value. Previously, it will cause failure.

The resolve rule is that last tag wins.

Tested with: 
```
{
    "Resources": {
        "MyTopic": {
            "Type": "AWS::SNS::Topic",
            "Properties": {
                "Tags": [
                    {
                        "Key" : "keyname",
                        "Value" : "value1"
                    },
                    {
                        "Key" : "keyname",
                        "Value" : "value2"
                    }
                ]
            }
        }
    }
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
