### PR TITLE
include the tags at the stack level with getPreviousResourceTags() in update handler

### DIFF
--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/BaseHandlerStd.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/BaseHandlerStd.java
@@ -98,7 +98,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     return ProgressEvent.progress(model, callbackContext);
   }
 
-  protected ProgressEvent<ResourceModel, CallbackContext> modifyTags(AmazonWebServicesClientProxy proxy, ProxyClient<SnsClient> proxyClient, ResourceModel model, Map<String, String> desiredResourceTags, Set<Tag> existingTags, ProgressEvent<ResourceModel, CallbackContext> progress, Logger logger) {
+  protected ProgressEvent<ResourceModel, CallbackContext> modifyTags(AmazonWebServicesClientProxy proxy, ProxyClient<SnsClient> proxyClient, ResourceModel model, Set<Tag> currentTags, Set<Tag> existingTags, ProgressEvent<ResourceModel, CallbackContext> progress, Logger logger) {
     final Set<Tag> currentTags = Translator.convertResourceTagsToSet(desiredResourceTags);
     final Set<Tag> previousTags = new HashSet<>(Optional.ofNullable(existingTags).orElse(Collections.emptySet()));
     final Set<Tag> tagsToRemove = Sets.difference(previousTags, currentTags);

--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/BaseHandlerStd.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/BaseHandlerStd.java
@@ -99,7 +99,6 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
   }
 
   protected ProgressEvent<ResourceModel, CallbackContext> modifyTags(AmazonWebServicesClientProxy proxy, ProxyClient<SnsClient> proxyClient, ResourceModel model, Set<Tag> currentTags, Set<Tag> existingTags, ProgressEvent<ResourceModel, CallbackContext> progress, Logger logger) {
-    final Set<Tag> currentTags = Translator.convertResourceTagsToSet(desiredResourceTags);
     final Set<Tag> previousTags = new HashSet<>(Optional.ofNullable(existingTags).orElse(Collections.emptySet()));
     final Set<Tag> tagsToRemove = Sets.difference(previousTags, currentTags);
     final Set<Tag> tagsToAdd = Sets.difference(currentTags, previousTags);

--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/UpdateHandler.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/UpdateHandler.java
@@ -32,7 +32,11 @@ public class UpdateHandler extends BaseHandlerStd {
 
         final ResourceModel model = request.getDesiredResourceState();
         final ResourceModel previousModel = request.getPreviousResourceState();
-        final Map<String, String> desiredResourceTags = request.getDesiredResourceTags();
+
+        Set<Tag> previousModelTags = new HashSet<>(Optional.ofNullable(previousModel.getTags()).orElse(Collections.emptySet()));
+        Set<Tag> previousResourceTags = Sets.union(Translator.convertResourceTagsToSet(request.getPreviousResourceTags()), previousModelTags);
+        Set<Tag> desiredModelTags = new HashSet<>(Optional.ofNullable(model.getTags()).orElse(Collections.emptySet()));
+        Set<Tag> desiredResourceTags = Sets.union(Translator.convertResourceTagsToSet(request.getDesiredResourceTags()), desiredModelTags);
 
         Set<Subscription> desiredSubscription = new HashSet<>(Optional.ofNullable(model.getSubscription()).orElse(Collections.emptySet()));
         Set<Subscription> previousSubscription = new HashSet<>(Optional.ofNullable(previousModel.getSubscription()).orElse(Collections.emptySet()));
@@ -88,7 +92,7 @@ public class UpdateHandler extends BaseHandlerStd {
                 )
                 .then(progress -> removeSubscription(proxy, proxyClient, progress, logger))
                 .then(progress -> addSubscription(proxy, proxyClient, progress, toSubscribe, logger))
-                .then(progress -> modifyTags(proxy, proxyClient, model, desiredResourceTags, previousModel.getTags(), progress, logger))
+                .then(progress -> modifyTags(proxy, proxyClient, model, desiredResourceTags, previousResourceTags, progress, logger))
                 .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- call getPreviousResourceTags() in order to get all the stack level tags so that we have all tags available for modify. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
