### PR TITLE
use request.getPreviousResourceTags() to tag from previous model

### DIFF
--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/BaseHandlerStd.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/BaseHandlerStd.java
@@ -91,9 +91,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
   }
 
   protected ProgressEvent<ResourceModel, CallbackContext> modifyTags(AmazonWebServicesClientProxy proxy, ProxyClient<SnsClient> proxyClient, ResourceModel model, Set<Tag> currentTags, Set<Tag> existingTags, ProgressEvent<ResourceModel, CallbackContext> progress, Logger logger) {
-    final Set<Tag> previousTags = new HashSet<>(Optional.ofNullable(existingTags).orElse(Collections.emptySet()));
-    final Set<Tag> tagsToRemove = Sets.difference(previousTags, currentTags);
-    final Set<Tag> tagsToAdd = Sets.difference(currentTags, previousTags);
+    final Set<Tag> tagsToRemove = Sets.difference(existingTags, currentTags);
+    final Set<Tag> tagsToAdd = Sets.difference(currentTags, existingTags);
 
     if (tagsToRemove.size() > 0) {
       invokeUnTagResource(proxyClient, model.getTopicArn(), tagsToRemove, logger);

--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/UpdateHandler.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/UpdateHandler.java
@@ -33,10 +33,8 @@ public class UpdateHandler extends BaseHandlerStd {
         final ResourceModel model = request.getDesiredResourceState();
         final ResourceModel previousModel = request.getPreviousResourceState();
 
-        Set<Tag> previousModelTags = new HashSet<>(Optional.ofNullable(previousModel.getTags()).orElse(Collections.emptySet()));
-        Set<Tag> previousResourceTags = Sets.union(Translator.convertResourceTagsToSet(request.getPreviousResourceTags()), previousModelTags);
-        Set<Tag> desiredModelTags = new HashSet<>(Optional.ofNullable(model.getTags()).orElse(Collections.emptySet()));
-        Set<Tag> desiredResourceTags = Sets.union(Translator.convertResourceTagsToSet(request.getDesiredResourceTags()), desiredModelTags);
+        Set<Tag> previousResourceTags = Translator.convertResourceTagsToSet(request.getPreviousResourceTags());
+        Set<Tag> desiredResourceTags = Translator.convertResourceTagsToSet(request.getDesiredResourceTags());
 
         Set<Subscription> desiredSubscription = new HashSet<>(Optional.ofNullable(model.getSubscription()).orElse(Collections.emptySet()));
         Set<Subscription> previousSubscription = new HashSet<>(Optional.ofNullable(previousModel.getSubscription()).orElse(Collections.emptySet()));

--- a/aws-sns-topic/src/test/java/software/amazon/sns/topic/UpdateHandlerTest.java
+++ b/aws-sns-topic/src/test/java/software/amazon/sns/topic/UpdateHandlerTest.java
@@ -15,9 +15,7 @@ import software.amazon.cloudformation.proxy.*;
 
 import java.time.Duration;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -122,16 +120,15 @@ public class UpdateHandlerTest extends AbstractTestBase {
         tags.put("key1", "value1");
         tags.put("key3", "value3");
 
-        final Set<Tag> oldTags = new HashSet<>();
-        oldTags.add(Tag.builder().key("key1").value("value1").build());
-        oldTags.add(Tag.builder().key("key2").value("value2").build());
+        final Map<String, String> oldTags = Maps.newHashMap();
+        oldTags.put("key1", "value1");
+        oldTags.put("key2", "value2");
 
         final ResourceModel model = ResourceModel.builder()
                 .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")
                 .build();
         final ResourceModel previousModel = ResourceModel.builder()
                 .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")
-                .tags(oldTags)
                 .build();
 
         Map<String, String> attributes = new HashMap<>();
@@ -149,6 +146,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(model)
                 .desiredResourceTags(tags)
+                .previousResourceTags(oldTags)
                 .previousResourceState(previousModel)
                 .build();
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
@@ -228,16 +226,15 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
     @Test
     public void handleRequest_SwallowUntagResourceAuthorizationException() {
-        final Set<Tag> oldTags = new HashSet<>();
-        oldTags.add(Tag.builder().key("key1").value("value1").build());
-        oldTags.add(Tag.builder().key("key2").value("value2").build());
+        final Map<String, String> oldTags = new HashMap<>();
+        oldTags.put("key1", "value1");
+        oldTags.put("key2", "value2");
 
         final ResourceModel model = ResourceModel.builder()
                 .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")
                 .build();
         final ResourceModel previousModel = ResourceModel.builder()
                 .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")
-                .tags(oldTags)
                 .build();
 
         Map<String, String> attributes = new HashMap<>();
@@ -252,6 +249,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(model)
                 .previousResourceState(previousModel)
+                .previousResourceTags(oldTags)
                 .build();
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
@@ -295,16 +293,15 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
     @Test
     public void handleRequest_UntagResourceException() {
-        final Set<Tag> oldTags = new HashSet<>();
-        oldTags.add(Tag.builder().key("key1").value("value1").build());
-        oldTags.add(Tag.builder().key("key2").value("value2").build());
+        final Map<String, String> oldTags = new HashMap<>();
+        oldTags.put("key1", "value1");
+        oldTags.put("key2", "value2");
 
         final ResourceModel model = ResourceModel.builder()
                 .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")
                 .build();
         final ResourceModel previousModel = ResourceModel.builder()
                 .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")
-                .tags(oldTags)
                 .build();
 
         Map<String, String> attributes = new HashMap<>();
@@ -320,6 +317,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(model)
                 .previousResourceState(previousModel)
+                .previousResourceTags(oldTags)
                 .build();
         assertThrows(CfnGeneralServiceException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- use request.getPreviousResourceTags() to get previous tags from the previous model 
- remove some redundant code 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
