### PR TITLE
Change delete handler workflow to make it backwards compatible.

### DIFF
--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/DeleteHandler.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/DeleteHandler.java
@@ -35,21 +35,6 @@ public class DeleteHandler extends BaseHandlerStd {
                                 .progress()
                 )
                 .then(progress ->
-                        proxy.initiate("AWS-SNS-Topic::Unsubscribe", proxyClient, model, callbackContext)
-                                .translateToServiceRequest(Translator::translateToListSubscriptionByTopic)
-                                .makeServiceCall((listSubscriptionsByTopicRequest, client) -> {
-                                    ListSubscriptionsByTopicResponse response = proxy.injectCredentialsAndInvokeV2(listSubscriptionsByTopicRequest, client.client()::listSubscriptionsByTopic);
-                                    List<String> arnList = Translator.streamOfOrEmpty(response.subscriptions())
-                                            .map(Subscription::subscriptionArn)
-                                            .collect(Collectors.toList());
-                                    callbackContext.setSubscriptionArnToUnsubscribe(arnList);
-                                    return response;
-                                })
-                                .progress()
-
-                )
-                .then(progress -> removeSubscription(proxy, proxyClient, progress, logger))
-                .then(progress ->
                         proxy.initiate("AWS-SNS-Topic::Delete", proxyClient, model, callbackContext)
                                 .translateToServiceRequest(Translator::translateToDeleteTopic)
                                 .makeServiceCall((deleteTopicRequest, client) -> proxy.injectCredentialsAndInvokeV2(deleteTopicRequest, client.client()::deleteTopic))

--- a/aws-sns-topic/src/test/java/software/amazon/sns/topic/DeleteHandlerTest.java
+++ b/aws-sns-topic/src/test/java/software/amazon/sns/topic/DeleteHandlerTest.java
@@ -62,17 +62,6 @@ public class DeleteHandlerTest extends AbstractTestBase {
                 .attributes(attributes)
                 .build();
         when(proxyClient.client().getTopicAttributes(any(GetTopicAttributesRequest.class))).thenReturn(getTopicAttributesResponse);
-        final ListSubscriptionsByTopicResponse listSubscriptionsByTopicResponse = ListSubscriptionsByTopicResponse.builder()
-                .subscriptions(software.amazon.awssdk.services.sns.model.Subscription.builder()
-                        .subscriptionArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name:27735157-80a9-4735-9427-090465a162d2")
-                        .endpoint("abc@xyz.com")
-                        .protocol("email")
-                        .build()
-                )
-                .build();
-        when(proxyClient.client().listSubscriptionsByTopic(any(ListSubscriptionsByTopicRequest.class))).thenReturn(listSubscriptionsByTopicResponse);
-        final UnsubscribeResponse unsubscribeResponse = UnsubscribeResponse.builder().build();
-        when(proxyClient.client().unsubscribe(any(UnsubscribeRequest.class))).thenReturn(unsubscribeResponse);
         final DeleteTopicResponse deleteTopicResponse = DeleteTopicResponse.builder().build();
         when(proxyClient.client().deleteTopic(any(DeleteTopicRequest.class))).thenReturn(deleteTopicResponse);
 
@@ -87,8 +76,6 @@ public class DeleteHandlerTest extends AbstractTestBase {
         assertThat(response.getErrorCode()).isNull();
 
         verify(proxyClient.client()).getTopicAttributes(any(GetTopicAttributesRequest.class));
-        verify(proxyClient.client()).listSubscriptionsByTopic(any(ListSubscriptionsByTopicRequest.class));
-        verify(proxyClient.client()).unsubscribe(any(UnsubscribeRequest.class));
         verify(proxyClient.client()).deleteTopic(any(DeleteTopicRequest.class));
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Change DELETE handler behaviour to make it backwards compatible.

Before the change, the workflow of delete handler is:
1. Check topic existence by calling `getTopicAttributes`
2. Get all subscriptions by calling `listSubscriptionsByTopic`
3. Call `unsubscribe` for all subscriptions got in previous step
4. Call `deleteTopic` to remove the topic.

In original implementation, it was just `deleteTopic` because if the topic has millions of subscriptions, the list-subscription will make CFN deletion dead, and we have subscription reaper to remove these subscriptions.

Meanwhile, during rolling out in FRA, we found out some customers will encounter `AuthorizationError` because their role doesn't have permission to `listSubscriptionsByTopic` or `unsubscribe`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
