### PR TITLE
Revert schema to make Tag, Subscription and TopicName to be backwards…

### DIFF
--- a/aws-sns-topic/aws-sns-topic.json
+++ b/aws-sns-topic/aws-sns-topic.json
@@ -15,7 +15,7 @@
         "Subscription": {
             "description": "The SNS subscriptions (endpoints) for this topic.",
             "type": "array",
-            "uniqueItems": true,
+            "uniqueItems": false,
             "insertionOrder": false,
             "items": {
                 "$ref": "#/definitions/Subscription"
@@ -31,7 +31,7 @@
         },
         "Tags": {
             "type": "array",
-            "uniqueItems": true,
+            "uniqueItems": false,
             "insertionOrder": false,
             "items": {
                 "$ref": "#/definitions/Tag"
@@ -39,9 +39,7 @@
         },
         "TopicName": {
             "description": "The name of the topic you want to create. Topic names must include only uppercase and lowercase ASCII letters, numbers, underscores, and hyphens, and must be between 1 and 256 characters long. FIFO topic names must end with .fifo.\n\nIf you don't specify a name, AWS CloudFormation generates a unique physical ID and uses that ID for the topic name. For more information, see Name Type.",
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 256
+            "type": "string"
         },
         "TopicArn": {
             "type": "string"
@@ -54,17 +52,11 @@
             "properties": {
                 "Key": {
                     "type": "string",
-                    "description": "The key name of the tag. You can specify a value that is 1 to 128 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, `_`, `.`, `/`, `=`, `+`, and `-`.",
-                    "minLength": 1,
-                    "maxLength": 128,
-                    "pattern": "^[a-zA-Z0-9_./=+-]{1,128}$"
+                    "description": "The key name of the tag. You can specify a value that is 1 to 128 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, `_`, `.`, `/`, `=`, `+`, and `-`."
                 },
                 "Value": {
                     "type": "string",
-                    "description": "The value for the tag. You can specify a value that is 0 to 256 characters in length.",
-                    "minLength": 0,
-                    "maxLength": 256,
-                    "pattern": "^[a-zA-Z0-9_./=+-]{0,256}$"
+                    "description": "The value for the tag. You can specify a value that is 0 to 256 characters in length."
                 }
             },
             "required": [
@@ -80,18 +72,7 @@
                     "type": "string"
                 },
                 "Protocol": {
-                    "type": "string",
-                    "enum": [
-                        "http",
-                        "https",
-                        "email",
-                        "email-json",
-                        "sms",
-                        "sqs",
-                        "application",
-                        "lambda",
-                        "firehose"
-                    ]
+                    "type": "string"
                 }
             },
             "required": [

--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/Configuration.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/Configuration.java
@@ -13,7 +13,7 @@ class Configuration extends BaseConfiguration {
 
     @Override
     public Map<String, String> resourceDefinedTags(ResourceModel resourceModel) {
-        return Optional.ofNullable(resourceModel.getTags()).orElse(Collections.emptySet())
+        return Optional.ofNullable(resourceModel.getTags()).orElse(Collections.emptyList())
                 .stream()
                 .collect(Collectors.toMap(Tag::getKey, Tag::getValue, (value1, value2) -> value2));
     }

--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/CreateHandler.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/CreateHandler.java
@@ -41,7 +41,7 @@ public class CreateHandler extends BaseHandlerStd {
                 .then(progress -> checkForPreCreateResourceExistence(request, proxyClient, progress))
                 .then(progress -> createTopicWithTags(proxy, model, desiredResourceTags, callbackContext, proxyClient))
                 .then(progress -> retryCreateTopicWithoutTags(proxy, model, callbackContext, proxyClient))
-                .then(progress -> addSubscription(proxy, proxyClient, progress, model.getSubscription(), logger))
+                .then(progress -> addSubscription(proxy, proxyClient, progress, model.getSubscription(), logger, true))
                 .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
     }
 

--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/Translator.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/Translator.java
@@ -97,12 +97,12 @@ public class Translator {
   static ResourceModel translateFromGetTopicAttributes(GetTopicAttributesResponse getTopicAttributesResponse, ListSubscriptionsByTopicResponse listSubscriptionsByTopicResponse, ListTagsForResourceResponse listTagsForResourceResponse) {
     Map<String, String> attributes = getTopicAttributesResponse.attributes();
 
-    Set<Subscription> subscriptions = streamOfOrEmpty(listSubscriptionsByTopicResponse.subscriptions())
+    List<Subscription> subscriptions = streamOfOrEmpty(listSubscriptionsByTopicResponse.subscriptions())
             .map(subscription -> Subscription.builder()
                     .endpoint(subscription.endpoint())
                     .protocol(subscription.protocol())
                     .build())
-            .collect(Collectors.toSet());
+            .collect(Collectors.toList());
 
 
     return ResourceModel.builder()
@@ -117,10 +117,10 @@ public class Translator {
             .build();
   }
 
-  static Set<Tag> translateTagsFromSdk(List<software.amazon.awssdk.services.sns.model.Tag> tags) {
+  static List<Tag> translateTagsFromSdk(List<software.amazon.awssdk.services.sns.model.Tag> tags) {
     return streamOfOrEmpty(tags)
             .map(tag -> Tag.builder().key(tag.key()).value(tag.value()).build())
-            .collect(Collectors.toSet());
+            .collect(Collectors.toList());
   }
 
   private static String getTopicNameFromArn(String arn) {
@@ -178,8 +178,8 @@ public class Translator {
             .build();
   }
 
-  static <T> Set<T> nullIfEmpty(Set<T> set) {
-    return set != null && set.isEmpty() ? null : Objects.requireNonNull(set);
+  static <T> List<T> nullIfEmpty(List<T> list) {
+    return list != null && list.isEmpty() ? null : Objects.requireNonNull(list);
   }
 
   static String nullIfEmpty(String s) {

--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/UpdateHandler.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/UpdateHandler.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.ArrayList;
 import java.util.stream.Collectors;
 
 public class UpdateHandler extends BaseHandlerStd {
@@ -36,8 +37,8 @@ public class UpdateHandler extends BaseHandlerStd {
         Set<Tag> previousResourceTags = Translator.convertResourceTagsToSet(request.getPreviousResourceTags());
         Set<Tag> desiredResourceTags = Translator.convertResourceTagsToSet(request.getDesiredResourceTags());
 
-        Set<Subscription> desiredSubscription = new HashSet<>(Optional.ofNullable(model.getSubscription()).orElse(Collections.emptySet()));
-        Set<Subscription> previousSubscription = new HashSet<>(Optional.ofNullable(previousModel.getSubscription()).orElse(Collections.emptySet()));
+        Set<Subscription> desiredSubscription = new HashSet<>(Optional.ofNullable(model.getSubscription()).orElse(Collections.emptyList()));
+        Set<Subscription> previousSubscription = new HashSet<>(Optional.ofNullable(previousModel.getSubscription()).orElse(Collections.emptyList()));
         Set<Subscription> toSubscribe = Sets.difference(desiredSubscription, previousSubscription);
         Set<Subscription> toUnsubscribe = Sets.difference(previousSubscription, desiredSubscription);
 
@@ -89,7 +90,7 @@ public class UpdateHandler extends BaseHandlerStd {
                                 .progress()
                 )
                 .then(progress -> removeSubscription(proxy, proxyClient, progress, logger))
-                .then(progress -> addSubscription(proxy, proxyClient, progress, toSubscribe, logger))
+                .then(progress -> addSubscription(proxy, proxyClient, progress, new ArrayList<>(toSubscribe), logger, false))
                 .then(progress -> modifyTags(proxy, proxyClient, model, desiredResourceTags, previousResourceTags, progress, logger))
                 .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
     }

--- a/aws-sns-topic/src/test/java/software/amazon/sns/topic/ConfigurationTest.java
+++ b/aws-sns-topic/src/test/java/software/amazon/sns/topic/ConfigurationTest.java
@@ -1,5 +1,6 @@
 package software.amazon.sns.topic;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.Test;
@@ -13,7 +14,7 @@ class ConfigurationTest {
     @Test
     public void testMergeDuplicateKeys() {
         final ResourceModel model = ResourceModel.builder()
-                .tags(ImmutableSet.of(new Tag("sameKey", "value1"), new Tag("sameKey", "value2")))
+                .tags(ImmutableList.of(new Tag("sameKey", "value1"), new Tag("sameKey", "value2")))
                 .build();
 
         final Configuration configuration = new Configuration();

--- a/aws-sns-topic/src/test/java/software/amazon/sns/topic/ReadHandlerTest.java
+++ b/aws-sns-topic/src/test/java/software/amazon/sns/topic/ReadHandlerTest.java
@@ -2,9 +2,9 @@ package software.amazon.sns.topic;
 
 import java.time.Duration;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.Map;
-import java.util.Set;
+import java.util.List;
 
 import software.amazon.awssdk.services.sns.SnsClient;
 import software.amazon.awssdk.services.sns.model.*;
@@ -58,9 +58,9 @@ public class ReadHandlerTest extends AbstractTestBase {
 
     @Test
     public void handleRequest_SimpleSuccess() {
-        final Set<Subscription> subscriptions = new HashSet<>();
+        final List<Subscription> subscriptions = new ArrayList<>();
         Subscription.builder().endpoint("abc@xyz.com").protocol("email").build();
-        final Set<Tag> tags = new HashSet<>();
+        final List<Tag> tags = new ArrayList<>();
         tags.add(Tag.builder().key("key1").value("value1").build());
 
         final ResourceModel model = ResourceModel.builder()
@@ -110,9 +110,9 @@ public class ReadHandlerTest extends AbstractTestBase {
 
     @Test
     public void handleRequest_attributesForDriftDetection() {
-        final Set<Subscription> subscriptions = new HashSet<>();
+        final List<Subscription> subscriptions = new ArrayList<>();
         Subscription.builder().endpoint("abc@xyz.com").protocol("email").build();
-        final Set<Tag> tags = new HashSet<>();
+        final List<Tag> tags = new ArrayList<>();
         tags.add(Tag.builder().key("key1").value("value1").build());
 
         final String topicArn = "arn:aws:sns:us-east-1:123456789012:sns-topic-name.fifo";


### PR DESCRIPTION
… compatible, also change wait time for addSubscription

*Issue #, if available:*
We had a few tickets during Uluru rollout that pattern in Tags, or enum in Subscriptions are preventing customers from creating new resource. Root cause is that the new aws-sns-topic.json in Uluru adds more restrictions on properties, and not backwards compatible.
*Description of changes:*
1. Compare current schema with non Uluru schema: https://schema.cloudformation.us-east-1.amazonaws.com/aws-sns-topic.json
    1. Remove pattern  and length check for Tags.
    2. Change uniqueItems for Subscriptions and Tags from true to false
    3. Remove min and max length for TopicName 
    4. Keep "insertionOrder": false,  for Tags and Subscription
    5. For `primaryIdentifier`, from previous CR, it should be the same behavior in Native and Uluru, so I am keeping this change.
2. Make accordingly change to `Translator` to translate Tags and Subscriptions from List, instead of Set.
3. For Contract Test, change the way of wait to:
    - Wait 6 seconds after creating a new topic (Verified in IAD, PDX, FRA and DUB, in most cases 5 seconds can pass, but not stable enough)
    - If it is creating stack, the expected list subscription by topic result count should equal to request subscription size.
       - If not, then wait for 2 seconds and list subscriptions by topic and compare size again
       - Max retries is 10 times.
       - Have verified the test `test_read_input_output_negative_match` in IAD, PDX, FRA and DUB

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
