### PR TITLE
Set ContentBasedDeduplication to false, if it is null in UpdateHandler

### DIFF
--- a/aws-sns-topic/docs/README.md
+++ b/aws-sns-topic/docs/README.md
@@ -14,7 +14,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
     "Properties" : {
         "<a href="#displayname" title="DisplayName">DisplayName</a>" : <i>String</i>,
         "<a href="#kmsmasterkeyid" title="KmsMasterKeyId">KmsMasterKeyId</a>" : <i>String</i>,
-        "<a href="#subscription" title="Subscription">Subscription</a>" : <i>[ <a href="subscription.md">Subscription</a>, ... ]</i>,
+        "<a href="#subscription" title="Subscription">Subscription</a>" : <i>[ [ <a href="subscription.md">Subscription</a>, ... ], ... ]</i>,
         "<a href="#fifotopic" title="FifoTopic">FifoTopic</a>" : <i>Boolean</i>,
         "<a href="#contentbaseddeduplication" title="ContentBasedDeduplication">ContentBasedDeduplication</a>" : <i>Boolean</i>,
         "<a href="#tags" title="Tags">Tags</a>" : <i>[ <a href="tag.md">Tag</a>, ... ]</i>,
@@ -31,6 +31,7 @@ Properties:
     <a href="#displayname" title="DisplayName">DisplayName</a>: <i>String</i>
     <a href="#kmsmasterkeyid" title="KmsMasterKeyId">KmsMasterKeyId</a>: <i>String</i>
     <a href="#subscription" title="Subscription">Subscription</a>: <i>
+      -
       - <a href="subscription.md">Subscription</a></i>
     <a href="#fifotopic" title="FifoTopic">FifoTopic</a>: <i>Boolean</i>
     <a href="#contentbaseddeduplication" title="ContentBasedDeduplication">ContentBasedDeduplication</a>: <i>Boolean</i>
@@ -69,7 +70,7 @@ The SNS subscriptions (endpoints) for this topic.
 
 _Required_: No
 
-_Type_: List of <a href="subscription.md">Subscription</a>
+_Type_: List of List of <a href="subscription.md">Subscription</a>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -116,10 +117,6 @@ If you don't specify a name, AWS CloudFormation generates a unique physical ID a
 _Required_: No
 
 _Type_: String
-
-_Minimum_: <code>1</code>
-
-_Maximum_: <code>256</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 

--- a/aws-sns-topic/docs/tag.md
+++ b/aws-sns-topic/docs/tag.md
@@ -30,12 +30,6 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
-
-_Maximum_: <code>128</code>
-
-_Pattern_: <code>^[a-zA-Z0-9_./=+-]{1,128}$</code>
-
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### Value
@@ -45,9 +39,5 @@ The value for the tag. You can specify a value that is 0 to 256 characters in le
 _Required_: Yes
 
 _Type_: String
-
-_Maximum_: <code>256</code>
-
-_Pattern_: <code>^[a-zA-Z0-9_./=+-]{0,256}$</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/BaseHandlerStd.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/BaseHandlerStd.java
@@ -109,7 +109,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     }
 
     for(final String subscriptionArn : unsubscribeArnList) {
-      if(!"PendingConfirmation".equals(subscriptionArn)) {
+      if(null != subscriptionArn && !"PendingConfirmation".equals(subscriptionArn)) {
         final ProgressEvent<ResourceModel, CallbackContext> progressEvent = proxy
                 .initiate("AWS-SNS-Topic::Unsubscribe-" + subscriptionArn.hashCode(), client, model, callbackContext)
                 .translateToServiceRequest(model1 -> Translator.translateToUnsubscribe(subscriptionArn))

--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/UpdateHandler.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/UpdateHandler.java
@@ -68,8 +68,8 @@ public class UpdateHandler extends BaseHandlerStd {
                     return progress;
                 })
                 .then(progress -> {
-                    String previousVal = previousModel.getContentBasedDeduplication() != null ? previousModel.getContentBasedDeduplication().toString() : null;
-                    String desiredVal =  model.getContentBasedDeduplication() != null ? model.getContentBasedDeduplication().toString() : null;
+                    String previousVal = previousModel.getContentBasedDeduplication() != null ? previousModel.getContentBasedDeduplication().toString() : "false";
+                    String desiredVal =  model.getContentBasedDeduplication() != null ? model.getContentBasedDeduplication().toString() : "false";
                     if (!StringUtils.equals(previousVal, desiredVal)) {
                         return proxy.initiate("AWS-SNS-Topic::Update::ContentBasedDeduplication", proxyClient, model, callbackContext)
                                 .translateToServiceRequest(m -> Translator.translateToSetAttributesRequest(m.getTopicArn(), TopicAttributeName.CONTENT_BASED_DEDUPLICATION, desiredVal))


### PR DESCRIPTION
*Issue #, if available:*
See some exception logs:
1. Try to set `ContentBasedDeduplication` to null when update handler, and SNS service only accept `true` or `false`.
2. See some NullPointer exception on BaseHandlerStd:114

*Description of changes:*
In old workflow the update of is 
```
final Boolean previousContentBasedDeduplicationValue = previousResource.isContentBasedDeduplication() != null ? previousResource.isContentBasedDeduplication() : Boolean.FALSE;
final Boolean currentContentBasedDeduplicationValue = currentResource.isContentBasedDeduplication() != null ? currentResource.isContentBasedDeduplication() : Boolean.FALSE;
```

So change that value in UpdateHandler to `false` instead of `null`.

Customer can have the workaround to set this to false in their CFN stack, so this should be fine.

For the NullPointerException issue, only `subscriptionArn.hashCode()` is possible to throw such exception. So add some additional check to confirm it is not null before `Unsubscribe`.

Also some docs update which should happen with previous PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
