### PR TITLE
Create handler performance

### DIFF
--- a/aws-sns-topic/docs/README.md
+++ b/aws-sns-topic/docs/README.md
@@ -14,7 +14,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
     "Properties" : {
         "<a href="#displayname" title="DisplayName">DisplayName</a>" : <i>String</i>,
         "<a href="#kmsmasterkeyid" title="KmsMasterKeyId">KmsMasterKeyId</a>" : <i>String</i>,
-        "<a href="#subscription" title="Subscription">Subscription</a>" : <i>[ <a href="subscription.md">Subscription</a>, ... ]</i>,
+        "<a href="#subscription" title="Subscription">Subscription</a>" : <i>[ [ <a href="subscription.md">Subscription</a>, ... ], ... ]</i>,
         "<a href="#fifotopic" title="FifoTopic">FifoTopic</a>" : <i>Boolean</i>,
         "<a href="#contentbaseddeduplication" title="ContentBasedDeduplication">ContentBasedDeduplication</a>" : <i>Boolean</i>,
         "<a href="#tags" title="Tags">Tags</a>" : <i>[ <a href="tag.md">Tag</a>, ... ]</i>,
@@ -31,6 +31,7 @@ Properties:
     <a href="#displayname" title="DisplayName">DisplayName</a>: <i>String</i>
     <a href="#kmsmasterkeyid" title="KmsMasterKeyId">KmsMasterKeyId</a>: <i>String</i>
     <a href="#subscription" title="Subscription">Subscription</a>: <i>
+      -
       - <a href="subscription.md">Subscription</a></i>
     <a href="#fifotopic" title="FifoTopic">FifoTopic</a>: <i>Boolean</i>
     <a href="#contentbaseddeduplication" title="ContentBasedDeduplication">ContentBasedDeduplication</a>: <i>Boolean</i>
@@ -69,7 +70,7 @@ The SNS subscriptions (endpoints) for this topic.
 
 _Required_: No
 
-_Type_: List of <a href="subscription.md">Subscription</a>
+_Type_: List of List of <a href="subscription.md">Subscription</a>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -116,10 +117,6 @@ If you don't specify a name, AWS CloudFormation generates a unique physical ID a
 _Required_: No
 
 _Type_: String
-
-_Minimum_: <code>1</code>
-
-_Maximum_: <code>256</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 

--- a/aws-sns-topic/docs/tag.md
+++ b/aws-sns-topic/docs/tag.md
@@ -30,12 +30,6 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
-
-_Maximum_: <code>128</code>
-
-_Pattern_: <code>^[a-zA-Z0-9_./=+-]{1,128}$</code>
-
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### Value
@@ -45,9 +39,5 @@ The value for the tag. You can specify a value that is 0 to 256 characters in le
 _Required_: Yes
 
 _Type_: String
-
-_Maximum_: <code>256</code>
-
-_Pattern_: <code>^[a-zA-Z0-9_./=+-]{0,256}$</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)

--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/BaseHandlerStd.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/BaseHandlerStd.java
@@ -109,7 +109,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     }
 
     for(final String subscriptionArn : unsubscribeArnList) {
-      if(!"PendingConfirmation".equals(subscriptionArn)) {
+      if(null != subscriptionArn && !"PendingConfirmation".equals(subscriptionArn)) {
         final ProgressEvent<ResourceModel, CallbackContext> progressEvent = proxy
                 .initiate("AWS-SNS-Topic::Unsubscribe-" + subscriptionArn.hashCode(), client, model, callbackContext)
                 .translateToServiceRequest(model1 -> Translator.translateToUnsubscribe(subscriptionArn))

--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/UpdateHandler.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/UpdateHandler.java
@@ -68,8 +68,8 @@ public class UpdateHandler extends BaseHandlerStd {
                     return progress;
                 })
                 .then(progress -> {
-                    String previousVal = previousModel.getContentBasedDeduplication() != null ? previousModel.getContentBasedDeduplication().toString() : null;
-                    String desiredVal =  model.getContentBasedDeduplication() != null ? model.getContentBasedDeduplication().toString() : null;
+                    String previousVal = previousModel.getContentBasedDeduplication() != null ? previousModel.getContentBasedDeduplication().toString() : "false";
+                    String desiredVal =  model.getContentBasedDeduplication() != null ? model.getContentBasedDeduplication().toString() : "false";
                     if (!StringUtils.equals(previousVal, desiredVal)) {
                         return proxy.initiate("AWS-SNS-Topic::Update::ContentBasedDeduplication", proxyClient, model, callbackContext)
                                 .translateToServiceRequest(m -> Translator.translateToSetAttributesRequest(m.getTopicArn(), TopicAttributeName.CONTENT_BASED_DEDUPLICATION, desiredVal))


### PR DESCRIPTION
*Issue #, if available:*
Some customers may not have `ListSubscriptionsByTopic` permission in the role calls CFN, and they will get AuthorizationError when create subscriptions in CreateHandler.
The original workaround for CT will call `ListSubscriptionsByTopic` and compare the result size with input request, when they not equal to each other will retry.
The call of `ListSubscriptionsByTopic` was wrapped in `invokeListSubscriptionsByTopic` which will swallow Authorization error and return an empty list. Then it will cause we retry 10 times in `addSubscription` as the permission issue has been hidden, and these retries are unnecessary.
*Description of changes:*
Directly call `client.injectCredentialsAndInvokeV2` in `addSubscription`, and if encounter `AuthorizationErrorException`, log the error and bypass the retry logic instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
