### PR TITLE
SNS Topic name compatible with the Native resource

### DIFF
--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/CreateHandler.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/CreateHandler.java
@@ -29,12 +29,12 @@ public class CreateHandler extends BaseHandlerStd {
         }
 
         if (StringUtils.isBlank(model.getTopicName())) {
-            String randomTopicName = IdentifierUtils.generateResourceIdentifier(request.getLogicalResourceIdentifier(), request.getClientRequestToken(), TOPIC_NAME_MAX_LENGTH);
+            String randomTopicName = IdentifierUtils.generateResourceIdentifier(request.getStackId(), request.getLogicalResourceIdentifier(), request.getClientRequestToken(), TOPIC_NAME_MAX_LENGTH);
             if (Boolean.TRUE.equals(model.getFifoTopic())) {
-                randomTopicName = IdentifierUtils.generateResourceIdentifier(request.getLogicalResourceIdentifier(), request.getClientRequestToken(), TOPIC_NAME_MAX_LENGTH - FIFO_TOPIC_EXTENSION.length());
+                randomTopicName = IdentifierUtils.generateResourceIdentifier(request.getStackId(), request.getLogicalResourceIdentifier(), request.getClientRequestToken(), TOPIC_NAME_MAX_LENGTH - FIFO_TOPIC_EXTENSION.length());
                 randomTopicName += FIFO_TOPIC_EXTENSION;
             }
-            model.setTopicName(randomTopicName.toLowerCase());
+            model.setTopicName(randomTopicName);
         }
 
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)

--- a/aws-sns-topic/src/test/java/software/amazon/sns/topic/CreateHandlerTest.java
+++ b/aws-sns-topic/src/test/java/software/amazon/sns/topic/CreateHandlerTest.java
@@ -96,6 +96,7 @@ public class CreateHandlerTest extends AbstractTestBase {
                 .clientRequestToken("dummy-token")
                 .region("us-east-1")
                 .awsAccountId("1234567890")
+                .stackId("stackid")
                 .build();
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
@@ -140,6 +141,7 @@ public class CreateHandlerTest extends AbstractTestBase {
                 .clientRequestToken("dummy-token")
                 .region("us-east-1")
                 .awsAccountId("1234567890")
+                .stackId("stackid")
                 .build();
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
@@ -175,7 +177,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         when(proxyClient.client().createTopic(any(CreateTopicRequest.class))).thenReturn(createTopicResponse);
         readHandlerMocks();
 
-        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).logicalResourceIdentifier("SnsTopic").clientRequestToken("dummy-token").build();
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).logicalResourceIdentifier("SnsTopic").clientRequestToken("dummy-token").stackId("stackid").build();
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
         validateResponseSuccess(response);
@@ -297,6 +299,7 @@ public class CreateHandlerTest extends AbstractTestBase {
                 .clientRequestToken("dummy-token")
                 .region("us-east-1")
                 .awsAccountId("1234567890")
+                .stackId("stackid")
                 .build();
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
@@ -335,6 +338,7 @@ public class CreateHandlerTest extends AbstractTestBase {
                 .clientRequestToken("dummy-token")
                 .region("us-east-1")
                 .awsAccountId("1234567890")
+                .stackId("stackid")
                 .build();
 
         assertThrows(CfnGeneralServiceException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));


### PR DESCRIPTION
*Issue #, if available: SNS topic name generation mismatch with native resource

*Description of changes: when the "TopicName" property is not specified in the CloudFormation template, CloudFormation must compute the topic name by concatenation of three strings: StackName, LogicalId, and Unique Id.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
