### PR TITLE
Add DataProtectionPolicy topic property.

### DIFF
--- a/aws-sns-topic/aws-sns-topic.json
+++ b/aws-sns-topic/aws-sns-topic.json
@@ -12,6 +12,10 @@
             "description": "The ID of an AWS-managed customer master key (CMK) for Amazon SNS or a custom CMK. For more information, see Key Terms. For more examples, see KeyId in the AWS Key Management Service API Reference.\n\nThis property applies only to [server-side-encryption](https://docs.aws.amazon.com/sns/latest/dg/sns-server-side-encryption.html).",
             "type": "string"
         },
+        "DataProtectionPolicy": {
+            "description": "The body of the policy document you want to use for this topic.\n\nYou can only add one policy per topic.\n\nThe policy must be in JSON string format.\n\nLength Constraints: Maximum length of 30720",
+            "type": "object"
+        },
         "Subscription": {
             "description": "The SNS subscriptions (endpoints) for this topic.",
             "type": "array",
@@ -106,14 +110,17 @@
                 "sns:Subscribe",
                 "sns:GetTopicAttributes",
                 "sns:ListTagsForResource",
-                "sns:ListSubscriptionsByTopic"
+                "sns:ListSubscriptionsByTopic",
+                "sns:GetDataProtectionPolicy",
+                "sns:PutDataProtectionPolicy"
             ]
         },
         "read": {
             "permissions": [
                 "sns:GetTopicAttributes",
                 "sns:ListTagsForResource",
-                "sns:ListSubscriptionsByTopic"
+                "sns:ListSubscriptionsByTopic",
+                "sns:GetDataProtectionPolicy"
             ]
         },
         "update": {
@@ -125,7 +132,9 @@
                 "sns:Unsubscribe",
                 "sns:GetTopicAttributes",
                 "sns:ListTagsForResource",
-                "sns:ListSubscriptionsByTopic"
+                "sns:ListSubscriptionsByTopic",
+                "sns:GetDataProtectionPolicy",
+                "sns:PutDataProtectionPolicy"
             ]
         },
         "delete": {

--- a/aws-sns-topic/docs/README.md
+++ b/aws-sns-topic/docs/README.md
@@ -14,6 +14,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
     "Properties" : {
         "<a href="#displayname" title="DisplayName">DisplayName</a>" : <i>String</i>,
         "<a href="#kmsmasterkeyid" title="KmsMasterKeyId">KmsMasterKeyId</a>" : <i>String</i>,
+        "<a href="#dataprotectionpolicy" title="DataProtectionPolicy">DataProtectionPolicy</a>" : <i>Map</i>,
         "<a href="#subscription" title="Subscription">Subscription</a>" : <i>[ [ <a href="subscription.md">Subscription</a>, ... ], ... ]</i>,
         "<a href="#fifotopic" title="FifoTopic">FifoTopic</a>" : <i>Boolean</i>,
         "<a href="#contentbaseddeduplication" title="ContentBasedDeduplication">ContentBasedDeduplication</a>" : <i>Boolean</i>,
@@ -30,6 +31,7 @@ Type: AWS::SNS::Topic
 Properties:
     <a href="#displayname" title="DisplayName">DisplayName</a>: <i>String</i>
     <a href="#kmsmasterkeyid" title="KmsMasterKeyId">KmsMasterKeyId</a>: <i>String</i>
+    <a href="#dataprotectionpolicy" title="DataProtectionPolicy">DataProtectionPolicy</a>: <i>Map</i>
     <a href="#subscription" title="Subscription">Subscription</a>: <i>
       -
       - <a href="subscription.md">Subscription</a></i>
@@ -61,6 +63,22 @@ This property applies only to [server-side-encryption](https://docs.aws.amazon.c
 _Required_: No
 
 _Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### DataProtectionPolicy
+
+The body of the policy document you want to use for this topic.
+
+You can only add one policy per topic.
+
+The policy must be in JSON string format.
+
+Length Constraints: Maximum length of 30720
+
+_Required_: No
+
+_Type_: Map
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/aws-sns-topic/pom.xml
+++ b/aws-sns-topic/pom.xml
@@ -24,7 +24,7 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.17.235</version>
+                <version>2.17.269</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/aws-sns-topic/resource-role.yaml
+++ b/aws-sns-topic/resource-role.yaml
@@ -32,10 +32,12 @@ Resources:
                 Action:
                 - "sns:CreateTopic"
                 - "sns:DeleteTopic"
+                - "sns:GetDataProtectionPolicy"
                 - "sns:GetTopicAttributes"
                 - "sns:ListSubscriptionsByTopic"
                 - "sns:ListTagsForResource"
                 - "sns:ListTopics"
+                - "sns:PutDataProtectionPolicy"
                 - "sns:SetTopicAttributes"
                 - "sns:Subscribe"
                 - "sns:TagResource"

--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/Translator.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/Translator.java
@@ -1,9 +1,14 @@
 package software.amazon.sns.topic;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
 import software.amazon.awssdk.services.sns.model.CreateTopicRequest;
 import software.amazon.awssdk.services.sns.model.DeleteTopicRequest;
+import software.amazon.awssdk.services.sns.model.GetDataProtectionPolicyRequest;
+import software.amazon.awssdk.services.sns.model.GetDataProtectionPolicyResponse;
 import software.amazon.awssdk.services.sns.model.GetTopicAttributesRequest;
 import software.amazon.awssdk.services.sns.model.GetTopicAttributesResponse;
 import software.amazon.awssdk.services.sns.model.ListSubscriptionsByTopicRequest;
@@ -12,11 +17,14 @@ import software.amazon.awssdk.services.sns.model.ListTagsForResourceRequest;
 import software.amazon.awssdk.services.sns.model.ListTagsForResourceResponse;
 import software.amazon.awssdk.services.sns.model.ListTopicsRequest;
 import software.amazon.awssdk.services.sns.model.ListTopicsResponse;
+import software.amazon.awssdk.services.sns.model.PutDataProtectionPolicyRequest;
 import software.amazon.awssdk.services.sns.model.SetTopicAttributesRequest;
 import software.amazon.awssdk.services.sns.model.SubscribeRequest;
 import software.amazon.awssdk.services.sns.model.TagResourceRequest;
 import software.amazon.awssdk.services.sns.model.UnsubscribeRequest;
 import software.amazon.awssdk.services.sns.model.UntagResourceRequest;
+import software.amazon.awssdk.utils.CollectionUtils;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -24,80 +32,98 @@ import java.util.stream.Stream;
 
 /**
  * This class is a centralized placeholder for
- *  - api request construction
- *  - object translation to/from aws sdk
- *  - resource model construction for read/list handlers
+ * - api request construction
+ * - object translation to/from aws sdk
+ * - resource model construction for read/list handlers
  */
 
 public class Translator {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
+    static CreateTopicRequest translateToCreateTopicRequest(final ResourceModel model, Map<String, String> desiredResourceTags) {
 
-  static CreateTopicRequest translateToCreateTopicRequest(final ResourceModel model, Map<String, String> desiredResourceTags) {
+        final Set<Tag> tags = convertResourceTagsToSet(desiredResourceTags);
+        return CreateTopicRequest.builder()
+                .name(model.getTopicName())
+                .attributes(translateTopicAttributesToMap(model))
+                .tags(translateTagsToSdk(tags))
+                .dataProtectionPolicy(getDataProtectionPolicyAsString(model))
+                .build();
+    }
 
-    final Set<Tag> tags = convertResourceTagsToSet(desiredResourceTags);
-    return CreateTopicRequest.builder()
-            .name(model.getTopicName())
-            .attributes(translateTopicAttributesToMap(model))
-            .tags(translateTagsToSdk(tags))
-            .build();
-  }
+    static CreateTopicRequest translateToCreateTopicRequest(final ResourceModel model) {
+        return CreateTopicRequest.builder()
+                .name(model.getTopicName())
+                .attributes(translateTopicAttributesToMap(model))
+                .dataProtectionPolicy(getDataProtectionPolicyAsString(model))
+                .build();
+    }
 
-  static CreateTopicRequest translateToCreateTopicRequest(final ResourceModel model) {
-      return CreateTopicRequest.builder()
-              .name(model.getTopicName())
-              .attributes(translateTopicAttributesToMap(model))
-              .build();
-  }
+    static PutDataProtectionPolicyRequest translatePutDataProtectionPolicyRequest(final ResourceModel model) {
+        return PutDataProtectionPolicyRequest.builder()
+                .dataProtectionPolicy(getDataProtectionPolicyAsString(model))
+                .resourceArn(model.getTopicArn())
+                .build();
+    }
 
-  static Set<software.amazon.awssdk.services.sns.model.Tag> translateTagsToSdk(Set<Tag> tags) {
-    return streamOfOrEmpty(tags)
-            .map(tag -> software.amazon.awssdk.services.sns.model.Tag.builder().key(tag.getKey()).value(tag.getValue()).build())
-            .collect(Collectors.toSet());
-  }
+    static GetDataProtectionPolicyRequest getDataProtectionPolicyRequest(final String topicArn) {
+        return GetDataProtectionPolicyRequest.builder()
+                .resourceArn(topicArn)
+                .build();
+    }
 
-  static DeleteTopicRequest translateToDeleteTopic(final ResourceModel model) {
-    return DeleteTopicRequest.builder()
-            .topicArn(model.getTopicArn())
-            .build();
-  }
+    static Set<software.amazon.awssdk.services.sns.model.Tag> translateTagsToSdk(Set<Tag> tags) {
+        return streamOfOrEmpty(tags)
+                .map(tag -> software.amazon.awssdk.services.sns.model.Tag.builder().key(tag.getKey()).value(tag.getValue()).build())
+                .collect(Collectors.toSet());
+    }
 
-  static GetTopicAttributesRequest translateToGetTopicAttributes(final ResourceModel model) {
-    return GetTopicAttributesRequest.builder()
-            .topicArn(model.getTopicArn())
-            .build();
-  }
+    static DeleteTopicRequest translateToDeleteTopic(final ResourceModel model) {
+        return DeleteTopicRequest.builder()
+                .topicArn(model.getTopicArn())
+                .build();
+    }
 
-  static ListTopicsRequest translateToListTopicRequest(final String nextToken) {
-    return ListTopicsRequest.builder()
-            .nextToken(nextToken)
-            .build();
-  }
+    static GetTopicAttributesRequest translateToGetTopicAttributes(final ResourceModel model) {
+        return GetTopicAttributesRequest.builder()
+                .topicArn(model.getTopicArn())
+                .build();
+    }
 
-  static GetTopicAttributesRequest translateToGetTopicAttributes(String awsPartition, String region, String accountId, String topicName) {
-    String topicArn = String.format("arn:%s:sns:%s:%s:%s", awsPartition, region, accountId, topicName);
-    return GetTopicAttributesRequest.builder()
-            .topicArn(topicArn)
-            .build();
- }
+    static ListTopicsRequest translateToListTopicRequest(final String nextToken) {
+        return ListTopicsRequest.builder()
+                .nextToken(nextToken)
+                .build();
+    }
 
-  static List<ResourceModel> translateFromListTopicRequest(final ListTopicsResponse listTopicsResponse) {
-    return streamOfOrEmpty(listTopicsResponse.topics())
-            .map(topic -> ResourceModel.builder()
-                    .topicArn(topic.topicArn())
-                    .build())
-            .collect(Collectors.toList());
-  }
+    static GetTopicAttributesRequest translateToGetTopicAttributes(String awsPartition, String region, String accountId, String topicName) {
+        String topicArn = String.format("arn:%s:sns:%s:%s:%s", awsPartition, region, accountId, topicName);
+        return GetTopicAttributesRequest.builder()
+                .topicArn(topicArn)
+                .build();
+    }
 
-  static <T> Stream<T> streamOfOrEmpty(final Collection<T> collection) {
-    return Optional.ofNullable(collection)
-            .map(Collection::stream)
-            .orElseGet(Stream::empty);
-  }
+    static List<ResourceModel> translateFromListTopicRequest(final ListTopicsResponse listTopicsResponse) {
+        return streamOfOrEmpty(listTopicsResponse.topics())
+                .map(topic -> ResourceModel.builder()
+                        .topicArn(topic.topicArn())
+                        .build())
+                .collect(Collectors.toList());
+    }
 
-  static ResourceModel translateFromGetTopicAttributes(GetTopicAttributesResponse getTopicAttributesResponse, ListSubscriptionsByTopicResponse listSubscriptionsByTopicResponse, ListTagsForResourceResponse listTagsForResourceResponse) {
-    Map<String, String> attributes = getTopicAttributesResponse.attributes();
+    static <T> Stream<T> streamOfOrEmpty(final Collection<T> collection) {
+        return Optional.ofNullable(collection)
+                .map(Collection::stream)
+                .orElseGet(Stream::empty);
+    }
 
-    List<Subscription> subscriptions = streamOfOrEmpty(listSubscriptionsByTopicResponse.subscriptions())
+    static ResourceModel translateFromGetTopicAttributes(GetTopicAttributesResponse getTopicAttributesResponse,
+                                                         ListSubscriptionsByTopicResponse listSubscriptionsByTopicResponse,
+                                                         ListTagsForResourceResponse listTagsForResourceResponse,
+                                                         GetDataProtectionPolicyResponse getDataProtectionPolicyResponse) {
+        Map<String, String> attributes = getTopicAttributesResponse.attributes();
+
+        List<Subscription> subscriptions = streamOfOrEmpty(listSubscriptionsByTopicResponse.subscriptions())
             .map(subscription -> Subscription.builder()
                     .endpoint(subscription.endpoint())
                     .protocol(subscription.protocol())
@@ -105,17 +131,18 @@ public class Translator {
             .collect(Collectors.toList());
 
 
-    return ResourceModel.builder()
-            .topicArn(attributes.get(TopicAttributeName.TOPIC_ARN.toString()))
-            .topicName(getTopicNameFromArn(attributes.get(TopicAttributeName.TOPIC_ARN.toString())))
-            .displayName(nullIfEmpty(attributes.get(TopicAttributeName.DISPLAY_NAME.toString())))
-            .kmsMasterKeyId(nullIfEmpty(attributes.get(TopicAttributeName.KMS_MASTER_KEY_ID.toString())))
-            .fifoTopic(nullIfEmptyBoolean(attributes.get(TopicAttributeName.FIFO_TOPIC.toString())))
-            .contentBasedDeduplication(nullIfEmptyBoolean(attributes.get(TopicAttributeName.CONTENT_BASED_DEDUPLICATION.toString())))
-            .subscription(nullIfEmpty(subscriptions))
-            .tags(nullIfEmpty(translateTagsFromSdk(listTagsForResourceResponse.tags())))
-            .build();
-  }
+        return ResourceModel.builder()
+                .topicArn(attributes.get(TopicAttributeName.TOPIC_ARN.toString()))
+                .topicName(getTopicNameFromArn(attributes.get(TopicAttributeName.TOPIC_ARN.toString())))
+                .displayName(nullIfEmpty(attributes.get(TopicAttributeName.DISPLAY_NAME.toString())))
+                .kmsMasterKeyId(nullIfEmpty(attributes.get(TopicAttributeName.KMS_MASTER_KEY_ID.toString())))
+                .fifoTopic(nullIfEmptyBoolean(attributes.get(TopicAttributeName.FIFO_TOPIC.toString())))
+                .contentBasedDeduplication(nullIfEmptyBoolean(attributes.get(TopicAttributeName.CONTENT_BASED_DEDUPLICATION.toString())))
+                .dataProtectionPolicy(getDataProtectionPolicyResponse == null ? null : convertToJson(getDataProtectionPolicyResponse.dataProtectionPolicy()))
+                .subscription(nullIfEmpty(subscriptions))
+                .tags(nullIfEmpty(translateTagsFromSdk(listTagsForResourceResponse.tags())))
+                .build();
+    }
 
   static List<Tag> translateTagsFromSdk(List<software.amazon.awssdk.services.sns.model.Tag> tags) {
     return streamOfOrEmpty(tags)
@@ -123,94 +150,118 @@ public class Translator {
             .collect(Collectors.toList());
   }
 
-  private static String getTopicNameFromArn(String arn) {
-    String[] splitWords = arn.split(":");
-    return splitWords[splitWords.length - 1];
-  }
+    private static String getTopicNameFromArn(String arn) {
+        String[] splitWords = arn.split(":");
+        return splitWords[splitWords.length - 1];
+    }
 
-  static ListTagsForResourceRequest listTagsForResourceRequest(String id) {
-    return ListTagsForResourceRequest.builder()
-            .resourceArn(id)
-            .build();
-  }
+    static ListTagsForResourceRequest listTagsForResourceRequest(String id) {
+        return ListTagsForResourceRequest.builder()
+                .resourceArn(id)
+                .build();
+    }
 
-  static ListSubscriptionsByTopicRequest translateToListSubscriptionByTopic(ResourceModel model) {
-    return ListSubscriptionsByTopicRequest.builder()
-            .topicArn(model.getTopicArn())
-            .build();
-  }
+    static ListSubscriptionsByTopicRequest translateToListSubscriptionByTopic(ResourceModel model) {
+        return ListSubscriptionsByTopicRequest.builder()
+                .topicArn(model.getTopicArn())
+                .build();
+    }
 
-  public static UnsubscribeRequest translateToUnsubscribe(String subscriptionArn) {
-    return UnsubscribeRequest.builder()
-            .subscriptionArn(subscriptionArn)
-            .build();
-  }
+    public static UnsubscribeRequest translateToUnsubscribe(String subscriptionArn) {
+        return UnsubscribeRequest.builder()
+                .subscriptionArn(subscriptionArn)
+                .build();
+    }
 
-  static SubscribeRequest translateToSubscribeRequest(ResourceModel model, Subscription subscription) {
-    return SubscribeRequest.builder()
-            .topicArn(model.getTopicArn())
-            .protocol(subscription.getProtocol())
-            .endpoint(subscription.getEndpoint())
-            .build();
-  }
+    static SubscribeRequest translateToSubscribeRequest(ResourceModel model, Subscription subscription) {
+        return SubscribeRequest.builder()
+                .topicArn(model.getTopicArn())
+                .protocol(subscription.getProtocol())
+                .endpoint(subscription.getEndpoint())
+                .build();
+    }
 
-  static SetTopicAttributesRequest translateToSetAttributesRequest(String id, TopicAttributeName attributName, String attributeValue) {
-    return SetTopicAttributesRequest.builder()
-            .topicArn(id)
-            .attributeName(attributName.toString())
-            .attributeValue(attributeValue)
-            .build();
-  }
+    static SetTopicAttributesRequest translateToSetAttributesRequest(String id, TopicAttributeName attributName, String attributeValue) {
+        return SetTopicAttributesRequest.builder()
+                .topicArn(id)
+                .attributeName(attributName.toString())
+                .attributeValue(attributeValue)
+                .build();
+    }
 
-  static TagResourceRequest translateToTagRequest(String topicArn, Set<Tag> tags) {
-    return TagResourceRequest.builder()
-            .resourceArn(topicArn)
-            .tags(translateTagsToSdk(tags))
-            .build();
-  }
+    static TagResourceRequest translateToTagRequest(String topicArn, Set<Tag> tags) {
+        return TagResourceRequest.builder()
+                .resourceArn(topicArn)
+                .tags(translateTagsToSdk(tags))
+                .build();
+    }
 
-  static UntagResourceRequest translateToUntagRequest(String topicArn, Set<Tag> tags) {
-    Set<String> tagKeys = streamOfOrEmpty(tags).map(Tag::getKey).collect(Collectors.toSet());
+    static UntagResourceRequest translateToUntagRequest(String topicArn, Set<Tag> tags) {
+        Set<String> tagKeys = streamOfOrEmpty(tags).map(Tag::getKey).collect(Collectors.toSet());
 
-    return UntagResourceRequest.builder()
-            .resourceArn(topicArn)
-            .tagKeys(tagKeys)
-            .build();
-  }
+        return UntagResourceRequest.builder()
+                .resourceArn(topicArn)
+                .tagKeys(tagKeys)
+                .build();
+    }
 
   static <T> List<T> nullIfEmpty(List<T> list) {
     return list != null && list.isEmpty() ? null : Objects.requireNonNull(list);
   }
 
-  static String nullIfEmpty(String s) {
-    return StringUtils.isEmpty(s) ? null : s;
-  }
-
-  static Boolean nullIfEmptyBoolean(String s) {
-      return StringUtils.isEmpty(s) ? null : Boolean.valueOf(s);
-  }
-
-  static Set<Tag> convertResourceTagsToSet(Map<String, String> resourceTags) {
-    Set<Tag> tags = Sets.newHashSet();
-    if (resourceTags != null) {
-      resourceTags.forEach((key, value) -> tags.add(Tag.builder().key(key).value(value).build()));
+    static String nullIfEmpty(String s) {
+        return StringUtils.isEmpty(s) ? null : s;
     }
-    return tags;
-  }
 
-  private static <V> void putIfNotNull(Map<String, String> attributeMap, String key, V value) {
-      if (value != null) {
-          attributeMap.put(key, value.toString());
-      }
-  }
+    static Boolean nullIfEmptyBoolean(String s) {
+        return StringUtils.isEmpty(s) ? null : Boolean.valueOf(s);
+    }
 
-  private static Map<String, String>  translateTopicAttributesToMap(ResourceModel model) {
-      Map<String, String> attributes = new HashMap<>();
+    static Set<Tag> convertResourceTagsToSet(Map<String, String> resourceTags) {
+        Set<Tag> tags = Sets.newHashSet();
+        if (resourceTags != null) {
+            resourceTags.forEach((key, value) -> tags.add(Tag.builder().key(key).value(value).build()));
+        }
+        return tags;
+    }
 
-      putIfNotNull(attributes, TopicAttributeName.DISPLAY_NAME.toString(), model.getDisplayName());
-      putIfNotNull(attributes, TopicAttributeName.KMS_MASTER_KEY_ID.toString(), model.getKmsMasterKeyId());
-      putIfNotNull(attributes, TopicAttributeName.FIFO_TOPIC.toString(), model.getFifoTopic());
-      putIfNotNull(attributes, TopicAttributeName.CONTENT_BASED_DEDUPLICATION.toString(), model.getContentBasedDeduplication());
-      return attributes;
-  }
+    static String getDataProtectionPolicyAsString(final ResourceModel model) {
+        if (CollectionUtils.isNullOrEmpty(model.getDataProtectionPolicy())) {
+            return "";
+        }
+        try {
+            return MAPPER.writeValueAsString(model.getDataProtectionPolicy());
+        } catch (JsonProcessingException e) {
+            throw new CfnInvalidRequestException(e);
+        }
+    }
+
+    private static Map<String,Object> convertToJson(String jsonString) {
+        Map<String, Object> obj = null;
+
+        if (StringUtils.isNotBlank(jsonString)) {
+            try {
+                obj = MAPPER.readValue(jsonString, new TypeReference<Map<String, Object>>() {});
+            } catch (Exception e) {
+                throw new CfnInvalidRequestException(e);
+            }
+        }
+        return obj;
+    }
+
+    private static <V> void putIfNotNull(Map<String, String> attributeMap, String key, V value) {
+        if (value != null) {
+            attributeMap.put(key, value.toString());
+        }
+    }
+
+    private static Map<String, String> translateTopicAttributesToMap(ResourceModel model) {
+        Map<String, String> attributes = new HashMap<>();
+
+        putIfNotNull(attributes, TopicAttributeName.DISPLAY_NAME.toString(), model.getDisplayName());
+        putIfNotNull(attributes, TopicAttributeName.KMS_MASTER_KEY_ID.toString(), model.getKmsMasterKeyId());
+        putIfNotNull(attributes, TopicAttributeName.FIFO_TOPIC.toString(), model.getFifoTopic());
+        putIfNotNull(attributes, TopicAttributeName.CONTENT_BASED_DEDUPLICATION.toString(), model.getContentBasedDeduplication());
+        return attributes;
+    }
 }

--- a/aws-sns-topic/src/test/java/software/amazon/sns/topic/AbstractTestBase.java
+++ b/aws-sns-topic/src/test/java/software/amazon/sns/topic/AbstractTestBase.java
@@ -2,20 +2,22 @@ package software.amazon.sns.topic;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.SneakyThrows;
 import software.amazon.awssdk.awscore.AwsRequest;
 import software.amazon.awssdk.awscore.AwsResponse;
-import software.amazon.awssdk.core.SdkClient;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.pagination.sync.SdkIterable;
 import software.amazon.awssdk.services.sns.SnsClient;
-import software.amazon.awssdk.services.sns.model.ListTagsForResourceResponse;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Credentials;
 import software.amazon.cloudformation.proxy.LoggerProxy;
 import software.amazon.cloudformation.proxy.ProxyClient;
 
 public class AbstractTestBase {
+  protected static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   protected static final Credentials MOCK_CREDENTIALS;
   protected static final LoggerProxy logger;
 
@@ -64,5 +66,10 @@ public class AbstractTestBase {
         return snsClient;
       }
     };
+  }
+
+  @SneakyThrows
+  String toJsonSafe(Object obj) {
+    return OBJECT_MAPPER.writeValueAsString(obj);
   }
 }

--- a/aws-sns-topic/src/test/java/software/amazon/sns/topic/ReadHandlerTest.java
+++ b/aws-sns-topic/src/test/java/software/amazon/sns/topic/ReadHandlerTest.java
@@ -10,6 +10,7 @@ import software.amazon.awssdk.services.sns.SnsClient;
 import software.amazon.awssdk.services.sns.model.*;
 import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
+import software.amazon.cloudformation.exceptions.CfnThrottlingException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -41,6 +42,7 @@ public class ReadHandlerTest extends AbstractTestBase {
     SnsClient client;
 
     private ReadHandler handler;
+    final GetDataProtectionPolicyResponse getDataProtectionPolicyResponse = GetDataProtectionPolicyResponse.builder().build();
 
     @BeforeEach
     public void setup() {
@@ -62,6 +64,8 @@ public class ReadHandlerTest extends AbstractTestBase {
         Subscription.builder().endpoint("abc@xyz.com").protocol("email").build();
         final List<Tag> tags = new ArrayList<>();
         tags.add(Tag.builder().key("key1").value("value1").build());
+        Map<String, Object> policy = new HashMap<>();
+        policy.put("key", "val");
 
         final ResourceModel model = ResourceModel.builder()
                 .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")
@@ -69,6 +73,7 @@ public class ReadHandlerTest extends AbstractTestBase {
                 .displayName("topic-display-name")
                 .subscription(subscriptions)
                 .tags(tags)
+                .dataProtectionPolicy(policy)
                 .build();
 
 
@@ -92,6 +97,8 @@ public class ReadHandlerTest extends AbstractTestBase {
                 .tags(software.amazon.awssdk.services.sns.model.Tag.builder().key("key1").value("value1").build())
                 .build();
         when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(listTagsForStreamResponse);
+        when(proxyClient.client().getDataProtectionPolicy(any(GetDataProtectionPolicyRequest.class)))
+                .thenReturn(GetDataProtectionPolicyResponse.builder().dataProtectionPolicy(toJsonSafe(policy)).build());
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).build();
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
@@ -106,6 +113,7 @@ public class ReadHandlerTest extends AbstractTestBase {
         verify(proxyClient.client()).getTopicAttributes(any(GetTopicAttributesRequest.class));
         verify(proxyClient.client()).listSubscriptionsByTopic(any(ListSubscriptionsByTopicRequest.class));
         verify(proxyClient.client()).listTagsForResource(any(ListTagsForResourceRequest.class));
+        verify(proxyClient.client()).getDataProtectionPolicy(any(GetDataProtectionPolicyRequest.class));
     }
 
     @Test
@@ -151,6 +159,7 @@ public class ReadHandlerTest extends AbstractTestBase {
         verify(proxyClient.client()).getTopicAttributes(any(GetTopicAttributesRequest.class));
         verify(proxyClient.client()).listSubscriptionsByTopic(any(ListSubscriptionsByTopicRequest.class));
         verify(proxyClient.client()).listTagsForResource(any(ListTagsForResourceRequest.class));
+        verify(proxyClient.client(), never()).getDataProtectionPolicy(any(GetDataProtectionPolicyRequest.class));
     }
 
     @Test
@@ -184,6 +193,7 @@ public class ReadHandlerTest extends AbstractTestBase {
         when(proxyClient.client().getTopicAttributes(any(GetTopicAttributesRequest.class))).thenReturn(getTopicAttributesResponse);
         when(proxyClient.client().listSubscriptionsByTopic(any(ListSubscriptionsByTopicRequest.class))).thenReturn(ListSubscriptionsByTopicResponse.builder().build());
         when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenThrow(AuthorizationErrorException.class);
+        when(proxyClient.client().getDataProtectionPolicy(any(GetDataProtectionPolicyRequest.class))).thenReturn(getDataProtectionPolicyResponse);
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).build();
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
@@ -235,6 +245,7 @@ public class ReadHandlerTest extends AbstractTestBase {
         when(proxyClient.client().getTopicAttributes(any(GetTopicAttributesRequest.class))).thenReturn(getTopicAttributesResponse);
         when(proxyClient.client().listSubscriptionsByTopic(any(ListSubscriptionsByTopicRequest.class))).thenThrow(AuthorizationErrorException.class);
         when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(ListTagsForResourceResponse.builder().build());
+        when(proxyClient.client().getDataProtectionPolicy(any(GetDataProtectionPolicyRequest.class))).thenReturn(getDataProtectionPolicyResponse);
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).build();
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
@@ -267,5 +278,78 @@ public class ReadHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).build();
         assertThrows(CfnGeneralServiceException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
+    }
+
+    @Test
+    public void handleRequest_SwallowGetDataProtectionPolicyAuthorizationErrorException() {
+        final ResourceModel model = ResourceModel.builder()
+                .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")
+                .build();
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(TopicAttributeName.DISPLAY_NAME.toString(), "topic-display-name");
+        attributes.put(TopicAttributeName.TOPIC_ARN.toString(), "arn:aws:sns:us-east-1:123456789012:sns-topic-name");
+        final GetTopicAttributesResponse getTopicAttributesResponse = GetTopicAttributesResponse.builder()
+                .attributes(attributes)
+                .build();
+
+        when(proxyClient.client().getTopicAttributes(any(GetTopicAttributesRequest.class))).thenReturn(getTopicAttributesResponse);
+        when(proxyClient.client().listSubscriptionsByTopic(any(ListSubscriptionsByTopicRequest.class))).thenReturn(ListSubscriptionsByTopicResponse.builder().build());
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(ListTagsForResourceResponse.builder().build());
+        when(proxyClient.client().getDataProtectionPolicy(any(GetDataProtectionPolicyRequest.class))).thenThrow(AuthorizationErrorException.class);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).build();
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    public void handleRequest_GetDataProtectionPolicyException() {
+        final ResourceModel model = ResourceModel.builder()
+                .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")
+                .build();
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(TopicAttributeName.DISPLAY_NAME.toString(), "topic-display-name");
+        attributes.put(TopicAttributeName.TOPIC_ARN.toString(), "arn:aws:sns:us-east-1:123456789012:sns-topic-name");
+        final GetTopicAttributesResponse getTopicAttributesResponse = GetTopicAttributesResponse.builder()
+                .attributes(attributes)
+                .build();
+
+        when(proxyClient.client().getTopicAttributes(any(GetTopicAttributesRequest.class))).thenReturn(getTopicAttributesResponse);
+        when(proxyClient.client().listSubscriptionsByTopic(any(ListSubscriptionsByTopicRequest.class))).thenReturn(ListSubscriptionsByTopicResponse.builder().build());
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(ListTagsForResourceResponse.builder().build());
+        when(proxyClient.client().getDataProtectionPolicy(any(GetDataProtectionPolicyRequest.class))).thenThrow(InternalErrorException.class);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).build();
+        assertThrows(CfnGeneralServiceException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
+    }
+
+    @Test
+    public void handleRequest_GetDataProtectionPolicyThrottleException() {
+        final ResourceModel model = ResourceModel.builder()
+                .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")
+                .build();
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(TopicAttributeName.DISPLAY_NAME.toString(), "topic-display-name");
+        attributes.put(TopicAttributeName.TOPIC_ARN.toString(), "arn:aws:sns:us-east-1:123456789012:sns-topic-name");
+        final GetTopicAttributesResponse getTopicAttributesResponse = GetTopicAttributesResponse.builder()
+                .attributes(attributes)
+                .build();
+
+        when(proxyClient.client().getTopicAttributes(any(GetTopicAttributesRequest.class))).thenReturn(getTopicAttributesResponse);
+        when(proxyClient.client().listSubscriptionsByTopic(any(ListSubscriptionsByTopicRequest.class))).thenReturn(ListSubscriptionsByTopicResponse.builder().build());
+        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(ListTagsForResourceResponse.builder().build());
+        when(proxyClient.client().getDataProtectionPolicy(any(GetDataProtectionPolicyRequest.class))).thenThrow(ThrottledException.class);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).build();
+        assertThrows(CfnThrottlingException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
     }
 }


### PR DESCRIPTION
Amazon SNS introduces the Data Protection Policy APIs, which enable customers to attach a data protection policy to an SNS topic. This allows topic owners to enable the new message data protection feature to audit and block sensitive data that is exchanged through their topics.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
