### PR TITLE
Fix the ThrottlingException Translation

### DIFF
--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/BaseHandlerStd.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/BaseHandlerStd.java
@@ -226,7 +226,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
   }
 
   private BaseHandlerException translateServiceExceptionToFailure(final SnsException ex) {
-    if (ex instanceof ThrottledException) {
+    if (ex instanceof ThrottledException || ex.isThrottlingException()) {
       return new CfnThrottlingException(ex); // CFN can retry on throttling error.
     }
     return new CfnGeneralServiceException(ex);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
For Tag/Untag APIs, the throttling exception thrown from service is not ThrottledException.
Here we use `ex.isThrottlingException()` as another condition to decide whether to throw `CfnThrottlingException`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
