### PR TITLE
Add SignatureVersion as a topic attribute as part of SHA256 feature

### DIFF
--- a/aws-sns-topic/aws-sns-topic.json
+++ b/aws-sns-topic/aws-sns-topic.json
@@ -47,6 +47,10 @@
         },
         "TopicArn": {
             "type": "string"
+        },
+        "SignatureVersion": {
+            "description": "Version of the Amazon SNS signature used. If the SignatureVersion is 1, Signature is a Base64-encoded SHA1withRSA signature of the Message, MessageId, Type, Timestamp, and TopicArn values. If the SignatureVersion is 2, Signature is a Base64-encoded SHA256withRSA signature of the Message, MessageId, Type, Timestamp, and TopicArn values.",
+            "type": "string"
         }
     },
     "definitions": {

--- a/aws-sns-topic/docs/README.md
+++ b/aws-sns-topic/docs/README.md
@@ -34,7 +34,7 @@ Properties:
     <a href="#kmsmasterkeyid" title="KmsMasterKeyId">KmsMasterKeyId</a>: <i>String</i>
     <a href="#dataprotectionpolicy" title="DataProtectionPolicy">DataProtectionPolicy</a>: <i>Map</i>
     <a href="#subscription" title="Subscription">Subscription</a>: <i>
-      - 
+      -
       - <a href="subscription.md">Subscription</a></i>
     <a href="#fifotopic" title="FifoTopic">FifoTopic</a>: <i>Boolean</i>
     <a href="#contentbaseddeduplication" title="ContentBasedDeduplication">ContentBasedDeduplication</a>: <i>Boolean</i>

--- a/aws-sns-topic/docs/README.md
+++ b/aws-sns-topic/docs/README.md
@@ -20,6 +20,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#contentbaseddeduplication" title="ContentBasedDeduplication">ContentBasedDeduplication</a>" : <i>Boolean</i>,
         "<a href="#tags" title="Tags">Tags</a>" : <i>[ <a href="tag.md">Tag</a>, ... ]</i>,
         "<a href="#topicname" title="TopicName">TopicName</a>" : <i>String</i>,
+        "<a href="#signatureversion" title="SignatureVersion">SignatureVersion</a>" : <i>String</i>
     }
 }
 </pre>
@@ -33,13 +34,14 @@ Properties:
     <a href="#kmsmasterkeyid" title="KmsMasterKeyId">KmsMasterKeyId</a>: <i>String</i>
     <a href="#dataprotectionpolicy" title="DataProtectionPolicy">DataProtectionPolicy</a>: <i>Map</i>
     <a href="#subscription" title="Subscription">Subscription</a>: <i>
-      -
+      - 
       - <a href="subscription.md">Subscription</a></i>
     <a href="#fifotopic" title="FifoTopic">FifoTopic</a>: <i>Boolean</i>
     <a href="#contentbaseddeduplication" title="ContentBasedDeduplication">ContentBasedDeduplication</a>: <i>Boolean</i>
     <a href="#tags" title="Tags">Tags</a>: <i>
       - <a href="tag.md">Tag</a></i>
     <a href="#topicname" title="TopicName">TopicName</a>: <i>String</i>
+    <a href="#signatureversion" title="SignatureVersion">SignatureVersion</a>: <i>String</i>
 </pre>
 
 ## Properties
@@ -137,6 +139,20 @@ _Required_: No
 _Type_: String
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### SignatureVersion
+
+Version of the Amazon SNS signature used.
+
+* If the SignatureVersion is 1, Signature is a Base64-encoded SHA1withRSA signature of the Message, MessageId, Type, Timestamp, and TopicArn values.
+
+* If the SignatureVersion is 2, Signature is a Base64-encoded SHA256withRSA signature of the Message, MessageId, Type, Timestamp, and TopicArn values.
+
+_Required_: No
+
+_Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 ## Return Values
 

--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/TopicAttributeName.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/TopicAttributeName.java
@@ -5,7 +5,8 @@ public enum TopicAttributeName {
 	TOPIC_ARN("TopicArn"),
 	KMS_MASTER_KEY_ID("KmsMasterKeyId"),
 	CONTENT_BASED_DEDUPLICATION("ContentBasedDeduplication"),
-	FIFO_TOPIC("FifoTopic");
+	FIFO_TOPIC("FifoTopic"),
+	SIGNATURE_VERSION("SignatureVersion");
 
 	private final String value;
 

--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/Translator.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/Translator.java
@@ -136,6 +136,7 @@ public class Translator {
                 .topicName(getTopicNameFromArn(attributes.get(TopicAttributeName.TOPIC_ARN.toString())))
                 .displayName(nullIfEmpty(attributes.get(TopicAttributeName.DISPLAY_NAME.toString())))
                 .kmsMasterKeyId(nullIfEmpty(attributes.get(TopicAttributeName.KMS_MASTER_KEY_ID.toString())))
+                .signatureVersion(nullIfEmpty(attributes.get(TopicAttributeName.SIGNATURE_VERSION.toString())))
                 .fifoTopic(nullIfEmptyBoolean(attributes.get(TopicAttributeName.FIFO_TOPIC.toString())))
                 .contentBasedDeduplication(nullIfEmptyBoolean(attributes.get(TopicAttributeName.CONTENT_BASED_DEDUPLICATION.toString())))
                 .dataProtectionPolicy(getDataProtectionPolicyResponse == null ? null : convertToJson(getDataProtectionPolicyResponse.dataProtectionPolicy()))
@@ -260,6 +261,7 @@ public class Translator {
 
         putIfNotNull(attributes, TopicAttributeName.DISPLAY_NAME.toString(), model.getDisplayName());
         putIfNotNull(attributes, TopicAttributeName.KMS_MASTER_KEY_ID.toString(), model.getKmsMasterKeyId());
+        putIfNotNull(attributes, TopicAttributeName.SIGNATURE_VERSION.toString(), model.getSignatureVersion());
         putIfNotNull(attributes, TopicAttributeName.FIFO_TOPIC.toString(), model.getFifoTopic());
         putIfNotNull(attributes, TopicAttributeName.CONTENT_BASED_DEDUPLICATION.toString(), model.getContentBasedDeduplication());
         return attributes;

--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/UpdateHandler.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/UpdateHandler.java
@@ -78,6 +78,15 @@ public class UpdateHandler extends BaseHandlerStd {
                     return progress;
                 })
                 .then(progress -> {
+                    if(!StringUtils.equals(model.getSignatureVersion(), previousModel.getSignatureVersion())) {
+                        return proxy.initiate("AWS-SNS-Topic::Update::SignatureVersion", proxyClient, model, callbackContext)
+                                .translateToServiceRequest(m -> Translator.translateToSetAttributesRequest(m.getTopicArn(), TopicAttributeName.SIGNATURE_VERSION, m.getSignatureVersion()))
+                                .makeServiceCall((setTopicAttributesRequest, client) -> proxy.injectCredentialsAndInvokeV2(setTopicAttributesRequest, client.client()::setTopicAttributes))
+                                .progress();
+                    }
+                    return progress;
+                })
+                .then(progress -> {
                     String previousVal = previousModel.getContentBasedDeduplication() != null ? previousModel.getContentBasedDeduplication().toString() : "false";
                     String desiredVal =  model.getContentBasedDeduplication() != null ? model.getContentBasedDeduplication().toString() : "false";
                     if (!StringUtils.equals(previousVal, desiredVal)) {

--- a/aws-sns-topic/src/test/java/software/amazon/sns/topic/CreateHandlerTest.java
+++ b/aws-sns-topic/src/test/java/software/amazon/sns/topic/CreateHandlerTest.java
@@ -162,10 +162,12 @@ public class CreateHandlerTest extends AbstractTestBase {
         final ResourceModel model = ResourceModel.builder()
                 .displayName("sns-topic")
                 .kmsMasterKeyId("dummy-kms-key-id")
+                .signatureVersion("2")
                 .build();
-
+                
         Map<String, String> attributes = new HashMap<>();
         attributes.put(TopicAttributeName.TOPIC_ARN.toString(), "arn:aws:sns:us-east-1:123456789012:sns-topic-name");
+        attributes.put(TopicAttributeName.SIGNATURE_VERSION.toString(), "2");
         final GetTopicAttributesResponse getTopicAttributesResponse = GetTopicAttributesResponse.builder()
                 .attributes(attributes)
                 .build();

--- a/aws-sns-topic/src/test/java/software/amazon/sns/topic/CreateHandlerTest.java
+++ b/aws-sns-topic/src/test/java/software/amazon/sns/topic/CreateHandlerTest.java
@@ -164,7 +164,7 @@ public class CreateHandlerTest extends AbstractTestBase {
                 .kmsMasterKeyId("dummy-kms-key-id")
                 .signatureVersion("2")
                 .build();
-                
+
         Map<String, String> attributes = new HashMap<>();
         attributes.put(TopicAttributeName.TOPIC_ARN.toString(), "arn:aws:sns:us-east-1:123456789012:sns-topic-name");
         attributes.put(TopicAttributeName.SIGNATURE_VERSION.toString(), "2");

--- a/aws-sns-topic/src/test/java/software/amazon/sns/topic/ReadHandlerTest.java
+++ b/aws-sns-topic/src/test/java/software/amazon/sns/topic/ReadHandlerTest.java
@@ -72,6 +72,7 @@ public class ReadHandlerTest extends AbstractTestBase {
                 .topicName("sns-topic-name")
                 .displayName("topic-display-name")
                 .subscription(subscriptions)
+                .signatureVersion("2")
                 .tags(tags)
                 .dataProtectionPolicy(policy)
                 .build();
@@ -80,6 +81,8 @@ public class ReadHandlerTest extends AbstractTestBase {
         Map<String, String> attributes = new HashMap<>();
         attributes.put(TopicAttributeName.DISPLAY_NAME.toString(), "topic-display-name");
         attributes.put(TopicAttributeName.TOPIC_ARN.toString(), "arn:aws:sns:us-east-1:123456789012:sns-topic-name");
+        attributes.put(TopicAttributeName.SIGNATURE_VERSION.toString(), "2");
+
         final GetTopicAttributesResponse getTopicAttributesResponse = GetTopicAttributesResponse.builder()
                 .attributes(attributes)
                 .build();
@@ -126,12 +129,14 @@ public class ReadHandlerTest extends AbstractTestBase {
         final String topicArn = "arn:aws:sns:us-east-1:123456789012:sns-topic-name.fifo";
         final String topicName = "sns-topic-name.fifo";
         final String topicDisplayName = "topic-display-name";
+        final String signatureVersion = "2";
 
         final ResourceModel model = ResourceModel.builder()
                 .topicArn(topicArn)
                 .topicName(topicName)
                 .displayName(topicDisplayName)
                 .subscription(subscriptions)
+                .signatureVersion(signatureVersion)
                 .tags(tags)
                 .build();
 
@@ -139,6 +144,7 @@ public class ReadHandlerTest extends AbstractTestBase {
         attributes.put(TopicAttributeName.DISPLAY_NAME.toString(), topicDisplayName);
         attributes.put(TopicAttributeName.TOPIC_ARN.toString(), topicArn);
         attributes.put(TopicAttributeName.FIFO_TOPIC.toString(), "true");
+        attributes.put(TopicAttributeName.SIGNATURE_VERSION.toString(), signatureVersion);
         attributes.put(TopicAttributeName.CONTENT_BASED_DEDUPLICATION.toString(), "true");
         final GetTopicAttributesResponse getTopicAttributesResponse = GetTopicAttributesResponse.builder()
                 .attributes(attributes)

--- a/aws-sns-topic/src/test/java/software/amazon/sns/topic/UpdateHandlerTest.java
+++ b/aws-sns-topic/src/test/java/software/amazon/sns/topic/UpdateHandlerTest.java
@@ -119,7 +119,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         attributes.put(TopicAttributeName.SIGNATURE_VERSION.toString(), "2");
         attributes.put(TopicAttributeName.TOPIC_ARN.toString(), "arn:aws:sns:us-east-1:123456789012:sns-topic-name");
         setupUpdateHandlerMocks(attributes);
-        
+
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).previousResourceState(previousModel).build();
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 

--- a/aws-sns-topic/src/test/java/software/amazon/sns/topic/UpdateHandlerTest.java
+++ b/aws-sns-topic/src/test/java/software/amazon/sns/topic/UpdateHandlerTest.java
@@ -72,6 +72,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         validateResponseSuccess(response);
         verify(proxyClient.client()).setTopicAttributes(any(SetTopicAttributesRequest.class));
         verify(proxyClient.client(), times(2)).getTopicAttributes(any(GetTopicAttributesRequest.class));
+        verify(proxyClient.client(), times(1)).setTopicAttributes(any(SetTopicAttributesRequest.class));
         verify(proxyClient.client(), times(2)).listSubscriptionsByTopic(any(ListSubscriptionsByTopicRequest.class));
         verify(proxyClient.client()).getDataProtectionPolicy(any(GetDataProtectionPolicyRequest.class));
     }
@@ -98,9 +99,37 @@ public class UpdateHandlerTest extends AbstractTestBase {
         validateResponseSuccess(response);
         verify(proxyClient.client()).setTopicAttributes(any(SetTopicAttributesRequest.class));
         verify(proxyClient.client(), times(2)).getTopicAttributes(any(GetTopicAttributesRequest.class));
+        verify(proxyClient.client(), times(1)).setTopicAttributes(any(SetTopicAttributesRequest.class));
         verify(proxyClient.client(), times(2)).listSubscriptionsByTopic(any(ListSubscriptionsByTopicRequest.class));
         verify(proxyClient.client()).getDataProtectionPolicy(any(GetDataProtectionPolicyRequest.class));
     }
+
+   @Test
+    public void handleRequest_SimpleSuccess_UpdateSignatureVersion() {
+        final ResourceModel model = ResourceModel.builder()
+                .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")
+                .signatureVersion("2")
+                .build();
+        final ResourceModel previousModel = ResourceModel.builder()
+                .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")
+                .signatureVersion("1")
+                .build();
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(TopicAttributeName.SIGNATURE_VERSION.toString(), "2");
+        attributes.put(TopicAttributeName.TOPIC_ARN.toString(), "arn:aws:sns:us-east-1:123456789012:sns-topic-name");
+        setupUpdateHandlerMocks(attributes);
+        
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).previousResourceState(previousModel).build();
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        validateResponseSuccess(response);
+        verify(proxyClient.client()).setTopicAttributes(any(SetTopicAttributesRequest.class));
+        verify(proxyClient.client(), times(2)).getTopicAttributes(any(GetTopicAttributesRequest.class));
+        verify(proxyClient.client(), times(1)).setTopicAttributes(any(SetTopicAttributesRequest.class));
+        verify(proxyClient.client(), times(2)).listSubscriptionsByTopic(any(ListSubscriptionsByTopicRequest.class));
+        verify(proxyClient.client()).getDataProtectionPolicy(any(GetDataProtectionPolicyRequest.class));
+   }
 
     @Test
     public void handleRequest_NotFound() {


### PR DESCRIPTION
*Description of changes:*
SNS has recently released support for message signing using SHA256. As part of the rollout, ```SignatureVersion``` has been added as an optional topic attribute. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
