### PR TITLE
Do not silently fail Tag/Untag/TagOnCreate permission issue

### DIFF
--- a/aws-sns-topic/docs/README.md
+++ b/aws-sns-topic/docs/README.md
@@ -142,11 +142,7 @@ _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/l
 
 #### SignatureVersion
 
-Version of the Amazon SNS signature used.
-
-* If the SignatureVersion is 1, Signature is a Base64-encoded SHA1withRSA signature of the Message, MessageId, Type, Timestamp, and TopicArn values.
-
-* If the SignatureVersion is 2, Signature is a Base64-encoded SHA256withRSA signature of the Message, MessageId, Type, Timestamp, and TopicArn values.
+Version of the Amazon SNS signature used. If the SignatureVersion is 1, Signature is a Base64-encoded SHA1withRSA signature of the Message, MessageId, Type, Timestamp, and TopicArn values. If the SignatureVersion is 2, Signature is a Base64-encoded SHA256withRSA signature of the Message, MessageId, Type, Timestamp, and TopicArn values.
 
 _Required_: No
 

--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/BaseHandlerStd.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/BaseHandlerStd.java
@@ -4,12 +4,7 @@ import com.google.common.collect.Sets;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.sns.SnsClient;
 import software.amazon.awssdk.services.sns.model.*;
-import software.amazon.cloudformation.exceptions.BaseHandlerException;
-import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
-import software.amazon.cloudformation.exceptions.CfnInternalFailureException;
-import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
-import software.amazon.cloudformation.exceptions.CfnNotFoundException;
-import software.amazon.cloudformation.exceptions.CfnThrottlingException;
+import software.amazon.cloudformation.exceptions.*;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -207,8 +202,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     try {
       proxyClient.injectCredentialsAndInvokeV2(Translator.translateToUntagRequest(topicArn, tagsToRemove), proxyClient.client()::untagResource);
     } catch (AuthorizationErrorException e) {
-      // fail silently in case the user does not have access to either stack level or resource level tags
       logger.log(String.format("AccessDenied error: %s for topic: %s", e.getMessage(), topicArn));
+      throw new CfnAccessDeniedException(e);
     } catch (SnsException e) {
       throw translateServiceExceptionToFailure(e);
     }
@@ -218,8 +213,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     try {
       proxyClient.injectCredentialsAndInvokeV2(Translator.translateToTagRequest(topicArn, tagsToAdd), proxyClient.client()::tagResource);
     } catch (AuthorizationErrorException e) {
-      // fail silently in case the user does not have access to either stack level or resource level tags
       logger.log(String.format("AccessDenied error: %s for topic: %s", e.getMessage(), topicArn));
+      throw new CfnAccessDeniedException(e);
     } catch (SnsException e) {
       throw translateServiceExceptionToFailure(e);
     }


### PR DESCRIPTION
*Issue #, if available:*
Internal ticket Id: D65597030

*Description of changes:*

Per internal ticket, due to historical reasons, we allowed customers to continue create/update stack while creating topic or tagging/untagging resource even customer's role doesn't have permission to Tag/UntagResource. In the code, we were silently swallow the AccessDenied issue when we see such issues.
For example, in previous implementation, when customers try to create topics with tags, if they don't have TagResource in their permission, the stack creation will continue to retry create topics without tags. Then the stack execution will not fail, all resources defined in the stack will be created, just without tags.

This was not an issue before, but after SNS supports TBAC, we should let customer be aware of this issue and add permissions for their roles.

This change is not backwards compatible, but if not fix, it will raise security concerns.

The customers meet all three conditions below will be impacted:
* Using customized role to execute stack operations
* There is no TagResource/UntagResource permission in the customized role
* The topics in the stack are created with tags, or updated to add or remove tags

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
