### PR TITLE
Support stack-level tags

### DIFF
--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/UpdateHandler.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/UpdateHandler.java
@@ -41,8 +41,11 @@ public class UpdateHandler extends BaseHandlerStd {
         final ResourceModel model = request.getDesiredResourceState();
         final ResourceModel previousModel = request.getPreviousResourceState();
 
-        Set<Tag> previousResourceTags = Translator.convertResourceTagsToSet(request.getPreviousResourceTags());
-        Set<Tag> desiredResourceTags = Translator.convertResourceTagsToSet(request.getDesiredResourceTags());
+        Set<Tag> previousTags = Translator.convertResourceTagsToSet(request.getPreviousResourceTags());
+        Set<Tag> desiredTags = Translator.convertResourceTagsToSet(request.getDesiredResourceTags());
+
+        previousTags.addAll(Translator.convertResourceTagsToSet(request.getPreviousSystemTags()));
+        desiredTags.addAll(Translator.convertResourceTagsToSet(request.getSystemTags()));
 
         Set<Subscription> desiredSubscription = new HashSet<>(Optional.ofNullable(model.getSubscription()).orElse(Collections.emptyList()));
         Set<Subscription> previousSubscription = new HashSet<>(Optional.ofNullable(previousModel.getSubscription()).orElse(Collections.emptyList()));
@@ -120,7 +123,7 @@ public class UpdateHandler extends BaseHandlerStd {
                 )
                 .then(progress -> removeSubscription(proxy, proxyClient, progress, logger))
                 .then(progress -> addSubscription(proxy, proxyClient, progress, new ArrayList<>(toSubscribe), logger))
-                .then(progress -> modifyTags(proxy, proxyClient, model, desiredResourceTags, previousResourceTags, progress, logger))
+                .then(progress -> modifyTags(proxy, proxyClient, model, desiredTags, previousTags, progress, logger))
                 .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
     }
 

--- a/aws-sns-topic/src/test/java/software/amazon/sns/topic/CreateHandlerTest.java
+++ b/aws-sns-topic/src/test/java/software/amazon/sns/topic/CreateHandlerTest.java
@@ -1,6 +1,7 @@
 package software.amazon.sns.topic;
 
 import com.google.common.collect.ImmutableMap;
+import org.assertj.core.util.Maps;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -93,6 +94,8 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(model)
+                .desiredResourceTags(Maps.newHashMap("KeyName", "Value"))
+                .systemTags(Maps.newHashMap("aws:cloudformation:logical-id", "Value1"))
                 .logicalResourceIdentifier("SnsTopic")
                 .clientRequestToken("dummy-token")
                 .region("us-east-1")
@@ -285,7 +288,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         when(proxyClient.client().createTopic(any(CreateTopicRequest.class))).thenThrow(AuthorizationErrorException.builder().message("Tagging Access Denied").build());
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .desiredResourceTags(ImmutableMap.of("KeyName", "Value"))
+                .desiredResourceTags(Maps.newHashMap("KeyName", "Value"))
                 .desiredResourceState(model)
                 .logicalResourceIdentifier("SnsTopic")
                 .clientRequestToken("dummy-token")
@@ -318,7 +321,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         when(proxyClient.client().createTopic(any(CreateTopicRequest.class))).thenThrow(InternalErrorException.class).thenReturn(createTopicResponse);
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .desiredResourceTags(ImmutableMap.of("KeyName", "Value"))
+                .desiredResourceTags(Maps.newHashMap("KeyName", "Value"))
                 .desiredResourceState(model)
                 .logicalResourceIdentifier("SnsTopic")
                 .clientRequestToken("dummy-token")

--- a/aws-sns-topic/src/test/java/software/amazon/sns/topic/UpdateHandlerTest.java
+++ b/aws-sns-topic/src/test/java/software/amazon/sns/topic/UpdateHandlerTest.java
@@ -157,6 +157,12 @@ public class UpdateHandlerTest extends AbstractTestBase {
         oldTags.put("key1", "value1");
         oldTags.put("key2", "value2");
 
+        final Map<String, String> systemTags = Maps.newHashMap();
+        systemTags.put("aws:cloudformation:logical-id", "value2");
+
+        final Map<String, String> oldSystemTags = Maps.newHashMap();
+        oldSystemTags.put("aws:cloudformation:logical-id", "value1");
+
         final ResourceModel model = ResourceModel.builder()
                 .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")
                 .build();
@@ -180,6 +186,8 @@ public class UpdateHandlerTest extends AbstractTestBase {
                 .desiredResourceState(model)
                 .desiredResourceTags(tags)
                 .previousResourceTags(oldTags)
+                .systemTags(systemTags)
+                .previousSystemTags(oldSystemTags)
                 .previousResourceState(previousModel)
                 .build();
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-sns/issues/67
*Description of changes:*
Support stack-level tags for SNS::Topic

Test result:

Key | Value
-- | --
aws:cloudformation:logical-id | TopicTest1
aws:cloudformation:stack-id | arn:aws:cloudformation:us-east-2:077943477367:stack/testSystemTags/73caad60-a1d2-11ed-8ff3-02cbd949ff64
aws:cloudformation:stack-name | testSystemTags
env | gamma
sysTag | a


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
