### PR TITLE
Swallow ListSubscriptionByTopic AuthzError in CreateHandler

### DIFF
--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/BaseHandlerStd.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/BaseHandlerStd.java
@@ -59,8 +59,14 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             return true;
         }
         int expectedSubCount = model.getSubscription().size();
-        ListSubscriptionsByTopicResponse listSubscriptionsByTopicResponse = proxyClient.injectCredentialsAndInvokeV2(Translator.translateToListSubscriptionByTopic(model), proxyClient.client()::listSubscriptionsByTopic);
-        return listSubscriptionsByTopicResponse.subscriptions().size() == expectedSubCount;
+        try {
+            ListSubscriptionsByTopicResponse listSubscriptionsByTopicResponse = proxyClient.injectCredentialsAndInvokeV2(Translator.translateToListSubscriptionByTopic(model), proxyClient.client()::listSubscriptionsByTopic);
+            return listSubscriptionsByTopicResponse.subscriptions().size() == expectedSubCount;
+        } catch (AuthorizationErrorException e) {
+            return true;
+        } catch (SnsException e) {
+            throw translateServiceExceptionToFailure(e);
+        }
     }
 
     protected boolean checkIfTopicAlreadyExist(


### PR DESCRIPTION
- Swallow AuthorizationErrorException when ListSubscriptionsByTopic in CreateHandler

*Issue #, if available:*

*Description of changes:*
We changed stabilization logic in previous PR, which alters some error handling behavior when ListSubscriptionsByTopic in CreateHandler.
For backwards compatible, will swallow AuthzError for that API in ListSubscriptionsByTopic in CreateHandler.

Though this permission is still required for update handler. So any customer doesn't have permission for this API will still see failures when they update their stacks.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
