### PR TITLE
Soft fail stack level only tags

### DIFF
--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/BaseHandlerStd.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/BaseHandlerStd.java
@@ -59,8 +59,14 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             return true;
         }
         int expectedSubCount = model.getSubscription().size();
-        ListSubscriptionsByTopicResponse listSubscriptionsByTopicResponse = proxyClient.injectCredentialsAndInvokeV2(Translator.translateToListSubscriptionByTopic(model), proxyClient.client()::listSubscriptionsByTopic);
-        return listSubscriptionsByTopicResponse.subscriptions().size() == expectedSubCount;
+        try {
+            ListSubscriptionsByTopicResponse listSubscriptionsByTopicResponse = proxyClient.injectCredentialsAndInvokeV2(Translator.translateToListSubscriptionByTopic(model), proxyClient.client()::listSubscriptionsByTopic);
+            return listSubscriptionsByTopicResponse.subscriptions().size() == expectedSubCount;
+        } catch (AuthorizationErrorException e) {
+            return true;
+        } catch (SnsException e) {
+            throw translateServiceExceptionToFailure(e);
+        }
     }
 
     protected boolean checkIfTopicAlreadyExist(

--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/CreateHandler.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/CreateHandler.java
@@ -7,7 +7,7 @@ import software.amazon.cloudformation.exceptions.*;
 import software.amazon.cloudformation.proxy.*;
 import software.amazon.cloudformation.resource.IdentifierUtils;
 
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 public class CreateHandler extends BaseHandlerStd {
@@ -23,7 +23,7 @@ public class CreateHandler extends BaseHandlerStd {
         this.logger = logger;
         logger.log("CreateHandler invoked in: "+ request.getStackId()+ " " +request.getLogicalResourceIdentifier());
         final ResourceModel model = request.getDesiredResourceState();
-        final Map<String, String> tagsList = request.getDesiredResourceTags() != null? request.getDesiredResourceTags(): Collections.emptyMap();
+        final Map<String, String> tagsList = request.getDesiredResourceTags() != null? new HashMap<>(request.getDesiredResourceTags()): new HashMap<>();
         if (request.getSystemTags() != null)
             tagsList.putAll(request.getSystemTags());
 
@@ -43,9 +43,29 @@ public class CreateHandler extends BaseHandlerStd {
                         .makeServiceCall((createRequest, client) -> {
                             if (checkIfTopicAlreadyExist(request, proxyClient, model.getTopicName(), logger))
                                 throw new CfnAlreadyExistsException(ResourceModel.TYPE_NAME, model.getTopicName());
+                            CreateTopicResponse createTopicResponse = null;
+                            boolean retryCreateWithoutTags = false;
                             try {
-                                CreateTopicResponse createTopicResponse = proxy.injectCredentialsAndInvokeV2(Translator.translateToCreateTopicRequest(model, tagsList), proxyClient.client()::createTopic);
+                                createTopicResponse = proxy.injectCredentialsAndInvokeV2(Translator.translateToCreateTopicRequest(model, tagsList), proxyClient.client()::createTopic);
                                 model.setTopicArn(createTopicResponse.topicArn());
+                            } catch (AuthorizationErrorException e) {
+                                if (request.getDesiredResourceTags() == null || request.getDesiredResourceTags().isEmpty()) {
+                                    retryCreateWithoutTags = true;
+                                }
+                                else {
+                                    throw new CfnAccessDeniedException(e);
+                                }
+                            } catch (SnsException e) {
+                                throw new CfnGeneralServiceException(e);
+                            }
+                            try {
+                                if (retryCreateWithoutTags) {
+                                    logger.log(
+                                            String.format("Retry create %s without tags", model.getTopicName())
+                                    );
+                                    createTopicResponse = proxy.injectCredentialsAndInvokeV2(Translator.translateToCreateTopicRequest(model), proxyClient.client()::createTopic);
+                                    model.setTopicArn(createTopicResponse.topicArn());
+                                }
                                 createSubscriptions(proxyClient, model.getSubscription(), model, logger);
                                 return createTopicResponse;
                             } catch (AuthorizationErrorException e) {

--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/UpdateHandler.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/UpdateHandler.java
@@ -41,11 +41,11 @@ public class UpdateHandler extends BaseHandlerStd {
         final ResourceModel model = request.getDesiredResourceState();
         final ResourceModel previousModel = request.getPreviousResourceState();
 
-        Set<Tag> previousTags = Translator.convertResourceTagsToSet(request.getPreviousResourceTags());
-        Set<Tag> desiredTags = Translator.convertResourceTagsToSet(request.getDesiredResourceTags());
+        Set<Tag> previousResourceTags = Translator.convertResourceTagsToSet(request.getPreviousResourceTags());
+        Set<Tag> desiredResourceTags = Translator.convertResourceTagsToSet(request.getDesiredResourceTags());
 
-        previousTags.addAll(Translator.convertResourceTagsToSet(request.getPreviousSystemTags()));
-        desiredTags.addAll(Translator.convertResourceTagsToSet(request.getSystemTags()));
+        Set<Tag> previousSystemTags = Translator.convertResourceTagsToSet(request.getPreviousSystemTags());
+        Set<Tag> desiredSystemTags = Translator.convertResourceTagsToSet(request.getSystemTags());
 
         Set<Subscription> desiredSubscription = new HashSet<>(Optional.ofNullable(model.getSubscription()).orElse(Collections.emptyList()));
         Set<Subscription> previousSubscription = new HashSet<>(Optional.ofNullable(previousModel.getSubscription()).orElse(Collections.emptyList()));
@@ -123,7 +123,8 @@ public class UpdateHandler extends BaseHandlerStd {
                 )
                 .then(progress -> removeSubscription(proxy, proxyClient, progress, logger))
                 .then(progress -> addSubscription(proxy, proxyClient, progress, new ArrayList<>(toSubscribe), logger))
-                .then(progress -> modifyTags(proxy, proxyClient, model, desiredTags, previousTags, progress, logger))
+                // Per test, the systemTags are not changed in previous and desired model, still leave current logic here as it doesn't impact logic, in case any future change
+                .then(progress -> modifyTags(proxy, proxyClient, model, desiredResourceTags, previousResourceTags, desiredSystemTags, previousSystemTags, progress, logger))
                 .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Per discussion offline, after we add support for stack-level tags, if customers doesn't have tagResource permission in their role, they will fail the related tag mutation calls.

For customers who don't have resource tags defined in template, it is a bad CX that their stack creation will fail.

We decided to soft-fail(swallow) the AuthorizationError for Tag mutation calls when there are no resource tags in stack.

For Update stack, after test, the desired and previous system tags will remain the same for request, so the logic is not actually working. I leave the code piece there in case future logic change.

##Test Result:
1. No tags in stack, don't have TagResource in role. ->  Topic is created with no tags.
2. No tags in stack, have TagResource in role. -> Topic is created with stack-level tags.
3. Tags in stack, don't have TagResource in role. -> Stack create fail.
4. Tags in stack, have TagResource in role. -> Stack create successful.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
