### PR TITLE
Revert "Soft fail stack level only tags"

### DIFF
--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/BaseHandlerStd.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/BaseHandlerStd.java
@@ -181,28 +181,15 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         return ProgressEvent.progress(model, callbackContext);
     }
 
-    protected ProgressEvent<ResourceModel, CallbackContext> modifyTags(
-            AmazonWebServicesClientProxy proxy,
-            ProxyClient<SnsClient> proxyClient,
-            ResourceModel model,
-            Set<Tag> desiredResourceTags,
-            Set<Tag> existingResourceTags,
-            Set<Tag> desiredSystemTags,
-            Set<Tag> existingSystemTags,
-            ProgressEvent<ResourceModel,CallbackContext> progress,
-            Logger logger
-    ) {
-        final Set<Tag> resourceTagsToRemove = Sets.difference(existingResourceTags, desiredResourceTags);
-        final Set<Tag> resourceTagsToAdd = Sets.difference(desiredResourceTags, existingResourceTags);
+    protected ProgressEvent<ResourceModel, CallbackContext> modifyTags(AmazonWebServicesClientProxy proxy, ProxyClient<SnsClient> proxyClient, ResourceModel model, Set<Tag> currentTags, Set<Tag> existingTags, ProgressEvent<ResourceModel, CallbackContext> progress, Logger logger) {
+        final Set<Tag> tagsToRemove = Sets.difference(existingTags, currentTags);
+        final Set<Tag> tagsToAdd = Sets.difference(currentTags, existingTags);
 
-        final Set<Tag> systemTagsToRemove = Sets.difference(existingSystemTags, desiredSystemTags);
-        final Set<Tag> systemTagsToAdd = Sets.difference(desiredSystemTags, existingSystemTags);
-
-        if (resourceTagsToRemove.size() > 0 || systemTagsToRemove.size() > 0) {
-            invokeUnTagResource(proxyClient, model.getTopicArn(), resourceTagsToRemove, systemTagsToRemove, logger);
+        if (tagsToRemove.size() > 0) {
+            invokeUnTagResource(proxyClient, model.getTopicArn(), tagsToRemove, logger);
         }
-        if (resourceTagsToAdd.size() > 0 || systemTagsToAdd.size() > 0) {
-            invokeTagResource(proxyClient, model.getTopicArn(), resourceTagsToAdd, systemTagsToAdd, logger);
+        if (tagsToAdd.size() > 0) {
+            invokeTagResource(proxyClient, model.getTopicArn(), tagsToAdd, logger);
         }
         return progress;
     }
@@ -266,32 +253,22 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         }
     }
 
-    private void invokeUnTagResource(final ProxyClient<SnsClient> proxyClient, final String topicArn, final Set<Tag> resourceTagsToRemove, final Set<Tag> systemTagsToRemove, final Logger logger) {
+    private void invokeUnTagResource(final ProxyClient<SnsClient> proxyClient, final String topicArn, final Set<Tag> tagsToRemove, final Logger logger) {
         try {
-            Set<Tag> tagsToRemove = new HashSet<>(resourceTagsToRemove);
-            tagsToRemove.addAll(systemTagsToRemove);
             proxyClient.injectCredentialsAndInvokeV2(Translator.translateToUntagRequest(topicArn, tagsToRemove), proxyClient.client()::untagResource);
         } catch (AuthorizationErrorException e) {
             logger.log(String.format("AccessDenied error: %s for topic: %s", e.getMessage(), topicArn));
-            if (resourceTagsToRemove.isEmpty())
-                // There is only systemTags to untag, but no permission for UntagResource, just skip
-                return;
             throw new CfnAccessDeniedException(e);
         } catch (SnsException e) {
             throw translateServiceExceptionToFailure(e);
         }
     }
 
-    private void invokeTagResource(final ProxyClient<SnsClient> proxyClient, final String topicArn, final Set<Tag> resourceTagsToAdd, final Set<Tag> systemTagsToAdd, final Logger logger) {
+    private void invokeTagResource(final ProxyClient<SnsClient> proxyClient, final String topicArn, final Set<Tag> tagsToAdd, final Logger logger) {
         try {
-            Set<Tag> tagsToAdd = new HashSet<>(resourceTagsToAdd);
-            tagsToAdd.addAll(systemTagsToAdd);
             proxyClient.injectCredentialsAndInvokeV2(Translator.translateToTagRequest(topicArn, tagsToAdd), proxyClient.client()::tagResource);
         } catch (AuthorizationErrorException e) {
             logger.log(String.format("AccessDenied error: %s for topic: %s", e.getMessage(), topicArn));
-            if (resourceTagsToAdd.isEmpty())
-                // There is only systemTags to tag, but no permission for TagResource, just skip
-                return;
             throw new CfnAccessDeniedException(e);
         } catch (SnsException e) {
             throw translateServiceExceptionToFailure(e);

--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/UpdateHandler.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/UpdateHandler.java
@@ -41,11 +41,11 @@ public class UpdateHandler extends BaseHandlerStd {
         final ResourceModel model = request.getDesiredResourceState();
         final ResourceModel previousModel = request.getPreviousResourceState();
 
-        Set<Tag> previousResourceTags = Translator.convertResourceTagsToSet(request.getPreviousResourceTags());
-        Set<Tag> desiredResourceTags = Translator.convertResourceTagsToSet(request.getDesiredResourceTags());
+        Set<Tag> previousTags = Translator.convertResourceTagsToSet(request.getPreviousResourceTags());
+        Set<Tag> desiredTags = Translator.convertResourceTagsToSet(request.getDesiredResourceTags());
 
-        Set<Tag> previousSystemTags = Translator.convertResourceTagsToSet(request.getPreviousSystemTags());
-        Set<Tag> desiredSystemTags = Translator.convertResourceTagsToSet(request.getSystemTags());
+        previousTags.addAll(Translator.convertResourceTagsToSet(request.getPreviousSystemTags()));
+        desiredTags.addAll(Translator.convertResourceTagsToSet(request.getSystemTags()));
 
         Set<Subscription> desiredSubscription = new HashSet<>(Optional.ofNullable(model.getSubscription()).orElse(Collections.emptyList()));
         Set<Subscription> previousSubscription = new HashSet<>(Optional.ofNullable(previousModel.getSubscription()).orElse(Collections.emptyList()));
@@ -132,8 +132,7 @@ public class UpdateHandler extends BaseHandlerStd {
                 )
                 .then(progress -> removeSubscription(proxy, proxyClient, progress, logger))
                 .then(progress -> addSubscription(proxy, proxyClient, progress, new ArrayList<>(toSubscribe), logger))
-                // Per test, the systemTags are not changed in previous and desired model, still leave current logic here as it doesn't impact logic, in case any future change
-                .then(progress -> modifyTags(proxy, proxyClient, model, desiredResourceTags, previousResourceTags, desiredSystemTags, previousSystemTags, progress, logger))
+                .then(progress -> modifyTags(proxy, proxyClient, model, desiredTags, previousTags, progress, logger))
                 .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
     }
 

--- a/aws-sns-topic/src/test/java/software/amazon/sns/topic/CreateHandlerTest.java
+++ b/aws-sns-topic/src/test/java/software/amazon/sns/topic/CreateHandlerTest.java
@@ -7,9 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.stubbing.Answer;
 import software.amazon.awssdk.services.sns.SnsClient;
 import software.amazon.awssdk.services.sns.model.*;
 import software.amazon.cloudformation.exceptions.*;
@@ -301,60 +299,6 @@ public class CreateHandlerTest extends AbstractTestBase {
                 .build();
 
         assertThrows(CfnAccessDeniedException.class, () -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger));
-    }
-
-    @Test
-    public void handleRequest_CreateWithOnlySystemTags_AuthorizationError() {
-        Map<String, String> attributes = new HashMap<>();
-        Map<String, String> systemTags = Maps.newHashMap("aws:cloudformation:stack-name", "systemTagValue");
-        final ResourceModel model = ResourceModel.builder()
-                .topicName("TopicName")
-                .build();
-
-        attributes.put(TopicAttributeName.TOPIC_ARN.toString(), "arn:aws:sns:us-east-1:123456789012:sns-topic-name");
-        final GetTopicAttributesResponse getTopicAttributesResponse = GetTopicAttributesResponse.builder()
-                .attributes(attributes)
-                .build();
-
-        when(proxyClient.client().getTopicAttributes(any(GetTopicAttributesRequest.class)))
-                .thenThrow(NotFoundException.builder().message("no topic found").build())
-                .thenReturn(getTopicAttributesResponse);
-
-        final CreateTopicResponse createTopicResponse = CreateTopicResponse.builder()
-                .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")
-                .build();
-
-        when(proxyClient.client().createTopic(any(CreateTopicRequest.class))).thenAnswer(new Answer<CreateTopicResponse>() {
-            @Override
-            public CreateTopicResponse answer(InvocationOnMock invocation) {
-                Object[] args = invocation.getArguments();
-                CreateTopicRequest createTopicRequest = (CreateTopicRequest) args[0];
-                if (createTopicRequest.hasTags() && !createTopicRequest.tags().isEmpty())
-                    throw AuthorizationErrorException.builder().message("Tagging Access Denied").build();
-                return createTopicResponse;
-            }
-        });
-
-        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .systemTags(systemTags)
-                .desiredResourceState(model)
-                .logicalResourceIdentifier("SnsTopic")
-                .clientRequestToken("dummy-token")
-                .region("us-east-1")
-                .awsAccountId("1234567890")
-                .stackId("stackid")
-                .build();
-
-        readHandlerMocks();
-
-        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
-        validateResponseSuccess(response);
-
-        verify(proxyClient.client(), times(2)).createTopic(any(CreateTopicRequest.class));
-        verify(proxyClient.client(), times(2)).getTopicAttributes(any(GetTopicAttributesRequest.class));
-        verify(proxyClient.client(), times(1)).listSubscriptionsByTopic(any(ListSubscriptionsByTopicRequest.class));
-        verify(proxyClient.client()).listTagsForResource(any(ListTagsForResourceRequest.class));
-        verify(proxyClient.client()).getDataProtectionPolicy(any(GetDataProtectionPolicyRequest.class));
     }
 
     @Test

--- a/aws-sns-topic/src/test/java/software/amazon/sns/topic/UpdateHandlerTest.java
+++ b/aws-sns-topic/src/test/java/software/amazon/sns/topic/UpdateHandlerTest.java
@@ -228,55 +228,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
     }
 
     @Test
-    public void handleRequest_OnlyTagUntagSystemTags_AuthorizationError() {
-        final Map<String, String> resourceTags = Maps.newHashMap();
-        resourceTags.put("key1", "value1");
-
-        final Map<String, String> oldResourceTags = Maps.newHashMap();
-        oldResourceTags.put("key1", "value1");
-
-        final Map<String, String> systemTags = Maps.newHashMap();
-        systemTags.put("aws:cloudformation:logical-id", "value2");
-
-        final Map<String, String> oldSystemTags = Maps.newHashMap();
-        oldSystemTags.put("aws:cloudformation:logical-id", "value1");
-
-        final ResourceModel model = ResourceModel.builder()
-                .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")
-                .build();
-        final ResourceModel previousModel = ResourceModel.builder()
-                .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")
-                .build();
-
-        Map<String, String> attributes = new HashMap<>();
-        attributes.put(TopicAttributeName.TOPIC_ARN.toString(), "arn:aws:sns:us-east-1:123456789012:sns-topic-name");
-        final GetTopicAttributesResponse getTopicAttributesResponse = GetTopicAttributesResponse.builder()
-                .attributes(attributes)
-                .build();
-        when(proxyClient.client().getTopicAttributes(any(GetTopicAttributesRequest.class))).thenReturn(getTopicAttributesResponse);
-        when(proxyClient.client().tagResource(any(TagResourceRequest.class))).thenThrow(AuthorizationErrorException.builder().message("Tagging Access Denied").build());
-        when(proxyClient.client().untagResource(any(UntagResourceRequest.class))).thenThrow(AuthorizationErrorException.builder().message("Tagging Access Denied").build());
-        readHandlerMocks();
-
-        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .desiredResourceState(model)
-                .desiredResourceTags(resourceTags)
-                .previousResourceTags(oldResourceTags)
-                .systemTags(systemTags)
-                .previousSystemTags(oldSystemTags)
-                .previousResourceState(previousModel)
-                .build();
-        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
-
-        validateResponseSuccess(response);
-        verify(proxyClient.client()).tagResource(any(TagResourceRequest.class));
-        verify(proxyClient.client()).untagResource(any(UntagResourceRequest.class));
-        verify(proxyClient.client(), times(2)).getTopicAttributes(any(GetTopicAttributesRequest.class));
-        verify(proxyClient.client(), times(2)).listSubscriptionsByTopic(any(ListSubscriptionsByTopicRequest.class));
-        verify(proxyClient.client()).getDataProtectionPolicy(any(GetDataProtectionPolicyRequest.class));
-    }
-
-    @Test
     public void handleRequest_SimpleSuccess_ContentBasedDeduplication() {
 
         String fifoTopicArn = "arn:aws:sns:us-east-1:123456789012:sns-topic-name.fifo";


### PR DESCRIPTION
Reverts aws-cloudformation/aws-cloudformation-resource-providers-sns#73

After checking with Tagris expected behavior, we should be able to add system tags even when customer is not having `TagResource` permission, and if system tags are not able to be added, resource creation should fail. We have altered the Authz logic in our Frontend service to support adding system tags when there is no tag permission, that is pending deploy.