### PR TITLE
Remove read after create to not require too many permissions in CreateHandler

### DIFF
--- a/aws-sns-topic/aws-sns-topic.json
+++ b/aws-sns-topic/aws-sns-topic.json
@@ -117,9 +117,6 @@
                 "sns:TagResource",
                 "sns:Subscribe",
                 "sns:GetTopicAttributes",
-                "sns:ListTagsForResource",
-                "sns:ListSubscriptionsByTopic",
-                "sns:GetDataProtectionPolicy",
                 "sns:PutDataProtectionPolicy"
             ]
         },
@@ -147,9 +144,7 @@
         },
         "delete": {
             "permissions": [
-                "sns:DeleteTopic",
-                "sns:ListSubscriptionsByTopic",
-                "sns:Unsubscribe"
+                "sns:DeleteTopic"
             ]
         },
         "list": {

--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/BaseHandlerStd.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/BaseHandlerStd.java
@@ -24,7 +24,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
     //For stabilization backoff, set the timeout to 2 mins and duration as 15 second for initial strategy
     public static final Constant BACKOFF_STRATEGY = Constant.of().timeout(Duration.ofMinutes(2L)).delay(Duration.ofSeconds(15L)).build();
-    private static final int DELAY_TIME_MILLI_SECS = 6000;
+    private static final int DELAY_TIME_MILLI_SECS = 8000;
 
     @Override
     public final ProgressEvent<ResourceModel, CallbackContext> handleRequest(
@@ -47,27 +47,6 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             final CallbackContext callbackContext,
             final ProxyClient<SnsClient> proxyClient,
             final Logger logger);
-
-    protected boolean stabilizeSubscriptions(
-            final CreateTopicRequest request,
-            final CreateTopicResponse response,
-            final ProxyClient<SnsClient> proxyClient,
-            final ResourceModel model,
-            final CallbackContext callbackContext
-    ) {
-        if (model.getSubscription() == null) {
-            return true;
-        }
-        int expectedSubCount = model.getSubscription().size();
-        try {
-            ListSubscriptionsByTopicResponse listSubscriptionsByTopicResponse = proxyClient.injectCredentialsAndInvokeV2(Translator.translateToListSubscriptionByTopic(model), proxyClient.client()::listSubscriptionsByTopic);
-            return listSubscriptionsByTopicResponse.subscriptions().size() == expectedSubCount;
-        } catch (AuthorizationErrorException e) {
-            return true;
-        } catch (SnsException e) {
-            throw translateServiceExceptionToFailure(e);
-        }
-    }
 
     protected boolean checkIfTopicAlreadyExist(
             final ResourceHandlerRequest<ResourceModel> request,

--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/BaseHandlerStd.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/BaseHandlerStd.java
@@ -24,7 +24,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
     //For stabilization backoff, set the timeout to 2 mins and duration as 15 second for initial strategy
     public static final Constant BACKOFF_STRATEGY = Constant.of().timeout(Duration.ofMinutes(2L)).delay(Duration.ofSeconds(15L)).build();
-    private static final int DELAY_TIME_MILLI_SECS = 8000;
+    private static final int DELAY_TIME_MILLI_SECS = 6000;
 
     @Override
     public final ProgressEvent<ResourceModel, CallbackContext> handleRequest(

--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/CreateHandler.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/CreateHandler.java
@@ -54,9 +54,8 @@ public class CreateHandler extends BaseHandlerStd {
                                 throw new CfnGeneralServiceException(e);
                             }
                         })
-                        .stabilize(this::stabilizeSubscriptions)
                         .progress()
                 )
-                .then(progress -> new ReadHandler().handleRequest(proxy, request, callbackContext, proxyClient, logger));
+                .defaultSuccessHandler(model);
     }
 }


### PR DESCRIPTION
Remove read after create to not require too many permissions in CreateHandler

*Issue #, if available:*
ListSubsByTopic permission issue we have in CreateHandler when stabilization.

*Description of changes:*

The current implementation of CreateHandler will call ReadHandler after all Create calls.
This will lead us to a weird permission mode that we will need all the List/Read API permissions if we add some new API involved feature in CreateHandler, and we have to handle the missing permission to be soft-fail.

After consulting with CloudFormation team, they suggest us directly return the model instead of calling ReadHandler.

This approach actually freed us from calling ListSubsByTopic for Topic stabilization. It may improve our contract test as well, but I still need to tune the wait time in DeleteHandler instead of just removing it. Because per test, if no wait, it will cause subscribe InternalFailure from SNS.

For this change, I removed the ReadHandler call in the execution of create progress and return resource model directly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
