### PR TITLE
fix update optional attribute TracingConfig

### DIFF
--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/TracingMode.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/TracingMode.java
@@ -1,0 +1,28 @@
+package software.amazon.sns.topic;
+
+/**
+ * Type of tracing mode in AWS service integration.
+ */
+public enum TracingMode {
+    /**
+     * Indicates that the current AWS service takes the user's trace context from upstream and passes it to downstream.
+     */
+    PASS_THROUGH("PassThrough"),
+
+    /**
+     * Indicates that the current AWS service creates vended segments representing itself by using user's trace context from
+     * upstream, and pass vended segment's trace context to downstream.
+     */
+    ACTIVE("Active");
+
+    private final String value;
+
+    TracingMode(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/UpdateHandler.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/UpdateHandler.java
@@ -94,7 +94,7 @@ public class UpdateHandler extends BaseHandlerStd {
                         return progress;
                     }
                     String previousVal = previousModel.getTracingConfig();
-                    String desiredVal =  model.getTracingConfig() != null ? model.getTracingConfig().toString() : "PassThrough";
+                    String desiredVal =  model.getTracingConfig() != null ? model.getTracingConfig().toString() : TracingMode.PASS_THROUGH.toString();
                     if(!StringUtils.equals(previousVal, desiredVal)) {
                         return proxy.initiate("AWS-SNS-Topic::Update::TracingConfig", proxyClient, model, callbackContext)
                                 .translateToServiceRequest(m -> Translator.translateToSetAttributesRequest(m.getTopicArn(), TopicAttributeName.TRACING_CONFIG, desiredVal))

--- a/aws-sns-topic/src/main/java/software/amazon/sns/topic/UpdateHandler.java
+++ b/aws-sns-topic/src/main/java/software/amazon/sns/topic/UpdateHandler.java
@@ -90,9 +90,14 @@ public class UpdateHandler extends BaseHandlerStd {
                     return progress;
                 })
                 .then(progress -> {
-                    if(!StringUtils.equals(model.getTracingConfig(), previousModel.getTracingConfig())) {
+                    if ( previousModel.getTracingConfig() == null && model.getTracingConfig() == null) {
+                        return progress;
+                    }
+                    String previousVal = previousModel.getTracingConfig();
+                    String desiredVal =  model.getTracingConfig() != null ? model.getTracingConfig().toString() : "PassThrough";
+                    if(!StringUtils.equals(previousVal, desiredVal)) {
                         return proxy.initiate("AWS-SNS-Topic::Update::TracingConfig", proxyClient, model, callbackContext)
-                                .translateToServiceRequest(m -> Translator.translateToSetAttributesRequest(m.getTopicArn(), TopicAttributeName.TRACING_CONFIG, m.getTracingConfig()))
+                                .translateToServiceRequest(m -> Translator.translateToSetAttributesRequest(m.getTopicArn(), TopicAttributeName.TRACING_CONFIG, desiredVal))
                                 .makeServiceCall((setTopicAttributesRequest, client) -> proxy.injectCredentialsAndInvokeV2(setTopicAttributesRequest, client.client()::setTopicAttributes))
                                 .progress();
                     }

--- a/aws-sns-topic/src/test/java/software/amazon/sns/topic/CreateHandlerTest.java
+++ b/aws-sns-topic/src/test/java/software/amazon/sns/topic/CreateHandlerTest.java
@@ -149,13 +149,13 @@ public class CreateHandlerTest extends AbstractTestBase {
                 .displayName("sns-topic")
                 .kmsMasterKeyId("dummy-kms-key-id")
                 .signatureVersion("2")
-                .tracingConfig("Active")
+                .tracingConfig(TracingMode.ACTIVE.toString())
                 .build();
 
         Map<String, String> attributes = new HashMap<>();
         attributes.put(TopicAttributeName.TOPIC_ARN.toString(), "arn:aws:sns:us-east-1:123456789012:sns-topic-name");
         attributes.put(TopicAttributeName.SIGNATURE_VERSION.toString(), "2");
-        attributes.put(TopicAttributeName.TRACING_CONFIG.toString(), "Active");
+        attributes.put(TopicAttributeName.TRACING_CONFIG.toString(), TracingMode.ACTIVE.toString());
         final GetTopicAttributesResponse getTopicAttributesResponse = GetTopicAttributesResponse.builder()
                 .attributes(attributes)
                 .build();

--- a/aws-sns-topic/src/test/java/software/amazon/sns/topic/ReadHandlerTest.java
+++ b/aws-sns-topic/src/test/java/software/amazon/sns/topic/ReadHandlerTest.java
@@ -73,7 +73,7 @@ public class ReadHandlerTest extends AbstractTestBase {
                 .displayName("topic-display-name")
                 .subscription(subscriptions)
                 .signatureVersion("2")
-                .tracingConfig("PassThrough")
+                .tracingConfig(TracingMode.PASS_THROUGH.toString())
                 .tags(tags)
                 .dataProtectionPolicy(policy)
                 .build();
@@ -83,7 +83,7 @@ public class ReadHandlerTest extends AbstractTestBase {
         attributes.put(TopicAttributeName.DISPLAY_NAME.toString(), "topic-display-name");
         attributes.put(TopicAttributeName.TOPIC_ARN.toString(), "arn:aws:sns:us-east-1:123456789012:sns-topic-name");
         attributes.put(TopicAttributeName.SIGNATURE_VERSION.toString(), "2");
-        attributes.put(TopicAttributeName.TRACING_CONFIG.toString(), "PassThrough");
+        attributes.put(TopicAttributeName.TRACING_CONFIG.toString(), TracingMode.PASS_THROUGH.toString());
 
         final GetTopicAttributesResponse getTopicAttributesResponse = GetTopicAttributesResponse.builder()
                 .attributes(attributes)
@@ -132,7 +132,7 @@ public class ReadHandlerTest extends AbstractTestBase {
         final String topicName = "sns-topic-name.fifo";
         final String topicDisplayName = "topic-display-name";
         final String signatureVersion = "2";
-        final String tracingConfig = "Active";
+        final String tracingConfig = TracingMode.ACTIVE.toString();
 
         final ResourceModel model = ResourceModel.builder()
                 .topicArn(topicArn)

--- a/aws-sns-topic/src/test/java/software/amazon/sns/topic/UpdateHandlerTest.java
+++ b/aws-sns-topic/src/test/java/software/amazon/sns/topic/UpdateHandlerTest.java
@@ -160,6 +160,84 @@ public class UpdateHandlerTest extends AbstractTestBase {
     }
 
     @Test
+    public void handleRequest_SimpleSuccess_RemoveActiveTracingConfig() {
+        final ResourceModel model = ResourceModel.builder()
+                .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")
+                .build();
+        final ResourceModel previousModel = ResourceModel.builder()
+                .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")
+                .tracingConfig("Active")
+                .build();
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(TopicAttributeName.TRACING_CONFIG.toString(), "PassThrough");
+        attributes.put(TopicAttributeName.TOPIC_ARN.toString(), "arn:aws:sns:us-east-1:123456789012:sns-topic-name");
+        setupUpdateHandlerMocks(attributes);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).previousResourceState(previousModel).build();
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        validateResponseSuccess(response);
+        verify(proxyClient.client()).setTopicAttributes(any(SetTopicAttributesRequest.class));
+        verify(proxyClient.client(), times(2)).getTopicAttributes(any(GetTopicAttributesRequest.class));
+        verify(proxyClient.client(), times(1)).setTopicAttributes(any(SetTopicAttributesRequest.class));
+        verify(proxyClient.client(), times(2)).listSubscriptionsByTopic(any(ListSubscriptionsByTopicRequest.class));
+        verify(proxyClient.client()).getDataProtectionPolicy(any(GetDataProtectionPolicyRequest.class));
+    }
+
+    @Test
+    public void handleRequest_SimpleSuccess_AddPassThroughTracingConfig() {
+        final ResourceModel model = ResourceModel.builder()
+                .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")
+                .tracingConfig("PassThrough")
+                .build();
+        final ResourceModel previousModel = ResourceModel.builder()
+                .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")
+                .build();
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(TopicAttributeName.TRACING_CONFIG.toString(), "PassThrough");
+        attributes.put(TopicAttributeName.TOPIC_ARN.toString(), "arn:aws:sns:us-east-1:123456789012:sns-topic-name");
+        setupUpdateHandlerMocks(attributes);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).previousResourceState(previousModel).build();
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        validateResponseSuccess(response);
+        verify(proxyClient.client()).setTopicAttributes(any(SetTopicAttributesRequest.class));
+        verify(proxyClient.client(), times(2)).getTopicAttributes(any(GetTopicAttributesRequest.class));
+        verify(proxyClient.client(), times(1)).setTopicAttributes(any(SetTopicAttributesRequest.class));
+        verify(proxyClient.client(), times(2)).listSubscriptionsByTopic(any(ListSubscriptionsByTopicRequest.class));
+        verify(proxyClient.client()).getDataProtectionPolicy(any(GetDataProtectionPolicyRequest.class));
+    }
+
+    @Test
+    public void handleRequest_SimpleSuccess_AddActiveTracingConfig() {
+        final ResourceModel model = ResourceModel.builder()
+                .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")
+                .tracingConfig("Active")
+                .build();
+        final ResourceModel previousModel = ResourceModel.builder()
+                .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")
+                .build();
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(TopicAttributeName.TRACING_CONFIG.toString(), "Active");
+        attributes.put(TopicAttributeName.TOPIC_ARN.toString(), "arn:aws:sns:us-east-1:123456789012:sns-topic-name");
+        setupUpdateHandlerMocks(attributes);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder().desiredResourceState(model).previousResourceState(previousModel).build();
+        final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+
+        validateResponseSuccess(response);
+        verify(proxyClient.client()).setTopicAttributes(any(SetTopicAttributesRequest.class));
+        verify(proxyClient.client(), times(2)).getTopicAttributes(any(GetTopicAttributesRequest.class));
+        verify(proxyClient.client(), times(1)).setTopicAttributes(any(SetTopicAttributesRequest.class));
+        verify(proxyClient.client(), times(2)).listSubscriptionsByTopic(any(ListSubscriptionsByTopicRequest.class));
+        verify(proxyClient.client()).getDataProtectionPolicy(any(GetDataProtectionPolicyRequest.class));
+    }
+
+    @Test
     public void handleRequest_NotFound() {
         final ResourceModel model = ResourceModel.builder()
                 .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")

--- a/aws-sns-topic/src/test/java/software/amazon/sns/topic/UpdateHandlerTest.java
+++ b/aws-sns-topic/src/test/java/software/amazon/sns/topic/UpdateHandlerTest.java
@@ -136,15 +136,15 @@ public class UpdateHandlerTest extends AbstractTestBase {
     public void handleRequest_SimpleSuccess_UpdateTracingConfig() {
         final ResourceModel model = ResourceModel.builder()
                 .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")
-                .tracingConfig("Active")
+                .tracingConfig(TracingMode.ACTIVE.toString())
                 .build();
         final ResourceModel previousModel = ResourceModel.builder()
                 .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")
-                .tracingConfig("PassThrough")
+                .tracingConfig(TracingMode.PASS_THROUGH.toString())
                 .build();
 
         Map<String, String> attributes = new HashMap<>();
-        attributes.put(TopicAttributeName.TRACING_CONFIG.toString(), "Active");
+        attributes.put(TopicAttributeName.TRACING_CONFIG.toString(), TracingMode.ACTIVE.toString());
         attributes.put(TopicAttributeName.TOPIC_ARN.toString(), "arn:aws:sns:us-east-1:123456789012:sns-topic-name");
         setupUpdateHandlerMocks(attributes);
 
@@ -166,11 +166,11 @@ public class UpdateHandlerTest extends AbstractTestBase {
                 .build();
         final ResourceModel previousModel = ResourceModel.builder()
                 .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")
-                .tracingConfig("Active")
+                .tracingConfig(TracingMode.ACTIVE.toString())
                 .build();
 
         Map<String, String> attributes = new HashMap<>();
-        attributes.put(TopicAttributeName.TRACING_CONFIG.toString(), "PassThrough");
+        attributes.put(TopicAttributeName.TRACING_CONFIG.toString(), TracingMode.PASS_THROUGH.toString());
         attributes.put(TopicAttributeName.TOPIC_ARN.toString(), "arn:aws:sns:us-east-1:123456789012:sns-topic-name");
         setupUpdateHandlerMocks(attributes);
 
@@ -189,14 +189,14 @@ public class UpdateHandlerTest extends AbstractTestBase {
     public void handleRequest_SimpleSuccess_AddPassThroughTracingConfig() {
         final ResourceModel model = ResourceModel.builder()
                 .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")
-                .tracingConfig("PassThrough")
+                .tracingConfig(TracingMode.PASS_THROUGH.toString())
                 .build();
         final ResourceModel previousModel = ResourceModel.builder()
                 .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")
                 .build();
 
         Map<String, String> attributes = new HashMap<>();
-        attributes.put(TopicAttributeName.TRACING_CONFIG.toString(), "PassThrough");
+        attributes.put(TopicAttributeName.TRACING_CONFIG.toString(), TracingMode.PASS_THROUGH.toString());
         attributes.put(TopicAttributeName.TOPIC_ARN.toString(), "arn:aws:sns:us-east-1:123456789012:sns-topic-name");
         setupUpdateHandlerMocks(attributes);
 
@@ -215,14 +215,14 @@ public class UpdateHandlerTest extends AbstractTestBase {
     public void handleRequest_SimpleSuccess_AddActiveTracingConfig() {
         final ResourceModel model = ResourceModel.builder()
                 .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")
-                .tracingConfig("Active")
+                .tracingConfig(TracingMode.ACTIVE.toString())
                 .build();
         final ResourceModel previousModel = ResourceModel.builder()
                 .topicArn("arn:aws:sns:us-east-1:123456789012:sns-topic-name")
                 .build();
 
         Map<String, String> attributes = new HashMap<>();
-        attributes.put(TopicAttributeName.TRACING_CONFIG.toString(), "Active");
+        attributes.put(TopicAttributeName.TRACING_CONFIG.toString(), TracingMode.ACTIVE.toString());
         attributes.put(TopicAttributeName.TOPIC_ARN.toString(), "arn:aws:sns:us-east-1:123456789012:sns-topic-name");
         setupUpdateHandlerMocks(attributes);
 


### PR DESCRIPTION
*Issue #, if available:*
CloudFormation update failed if user removes Topic attribute TracingConfig from template.
*Description of changes:*
Support users add, remove or update optional Topic attribute TracingConfig from CloudFormation template. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
