### PR TITLE
Add String type to PolicyDocument

### DIFF
--- a/aws-sns-topicpolicy/aws-sns-topicpolicy.json
+++ b/aws-sns-topicpolicy/aws-sns-topicpolicy.json
@@ -10,7 +10,10 @@
         },
         "PolicyDocument": {
             "description": "A policy document that contains permissions to add to the specified SNS topics.",
-            "type": "object"
+            "type": [
+                "object",
+                "string"
+            ]
         },
         "Topics": {
             "description": "The Amazon Resource Names (ARN) of the topics to which you want to add the policy. You can use the [Ref](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html)` function to specify an [AWS::SNS::Topic](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sns-topic.html) resource.",

--- a/aws-sns-topicpolicy/docs/README.md
+++ b/aws-sns-topicpolicy/docs/README.md
@@ -12,7 +12,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 {
     "Type" : "AWS::SNS::TopicPolicy",
     "Properties" : {
-        "<a href="#policydocument" title="PolicyDocument">PolicyDocument</a>" : <i>Map</i>,
+        "<a href="#policydocument" title="PolicyDocument">PolicyDocument</a>" : <i>Map, String</i>,
         "<a href="#topics" title="Topics">Topics</a>" : <i>[ String, ... ]</i>
     }
 }
@@ -23,7 +23,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 Type: AWS::SNS::TopicPolicy
 Properties:
-    <a href="#policydocument" title="PolicyDocument">PolicyDocument</a>: <i>Map</i>
+    <a href="#policydocument" title="PolicyDocument">PolicyDocument</a>: <i>Map, String</i>
     <a href="#topics" title="Topics">Topics</a>: <i>
       - String</i>
 </pre>
@@ -36,7 +36,7 @@ A policy document that contains permissions to add to the specified SNS topics.
 
 _Required_: Yes
 
-_Type_: Map
+_Type_: Map, String
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/aws-sns-topicpolicy/src/main/java/software/amazon/sns/topicpolicy/BaseHandlerStd.java
+++ b/aws-sns-topicpolicy/src/main/java/software/amazon/sns/topicpolicy/BaseHandlerStd.java
@@ -29,6 +29,7 @@ import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import static java.util.Objects.requireNonNull;
 
 import java.util.regex.Pattern;
+import java.util.Map;
 
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
 
@@ -116,11 +117,14 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
      * @return Returns policy document
      */
     protected String getPolicyDocument(final ResourceHandlerRequest<ResourceModel> request) {
-        try {
-            return MAPPER.writeValueAsString(request.getDesiredResourceState().getPolicyDocument());
-        } catch (JsonProcessingException e) {
-            throw new CfnInvalidRequestException(e);
+        if (request.getDesiredResourceState().getPolicyDocument() instanceof Map){
+            try {
+                return MAPPER.writeValueAsString(request.getDesiredResourceState().getPolicyDocument());
+            } catch (JsonProcessingException e) {
+                throw new CfnInvalidRequestException(e);
+            }
         }
+        return (String) request.getDesiredResourceState().getPolicyDocument();
     }
 
     /*

--- a/aws-sns-topicpolicy/src/main/java/software/amazon/sns/topicpolicy/CreateHandler.java
+++ b/aws-sns-topicpolicy/src/main/java/software/amazon/sns/topicpolicy/CreateHandler.java
@@ -33,7 +33,7 @@ public class CreateHandler extends BaseHandlerStd {
         else if (CollectionUtils.isNullOrEmpty(resourceModel.getTopics())) {
             return ProgressEvent.failed(resourceModel, callbackContext, null, "Value of property Topics must be of type List of String");
         }
-        else if (CollectionUtils.isNullOrEmpty(resourceModel.getPolicyDocument())) {
+        else if (resourceModel.getPolicyDocument() == null) {
             return ProgressEvent.failed(resourceModel, callbackContext, HandlerErrorCode.InvalidRequest, "Invalid parameter: Policy Error: null");
         }
 

--- a/aws-sns-topicpolicy/src/main/java/software/amazon/sns/topicpolicy/UpdateHandler.java
+++ b/aws-sns-topicpolicy/src/main/java/software/amazon/sns/topicpolicy/UpdateHandler.java
@@ -32,7 +32,7 @@ public class UpdateHandler extends BaseHandlerStd {
         else if (CollectionUtils.isNullOrEmpty(resourceModel.getTopics())) {
             return ProgressEvent.failed(resourceModel, callbackContext, null, "Value of property Topics must be of type List of String");
         }
-        else if (CollectionUtils.isNullOrEmpty(resourceModel.getPolicyDocument())) {
+        else if (resourceModel.getPolicyDocument() == null) {
             return ProgressEvent.failed(resourceModel, callbackContext, HandlerErrorCode.InvalidRequest, "Invalid parameter: Policy Error: null");
         }
 

--- a/aws-sns-topicpolicy/src/test/java/software/amazon/sns/topicpolicy/UpdateHandlerTest.java
+++ b/aws-sns-topicpolicy/src/test/java/software/amazon/sns/topicpolicy/UpdateHandlerTest.java
@@ -178,7 +178,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final ResourceModel model = ResourceModel.builder()
                 .id("aws-sns-topic-policy-id-InternalErrorException")
                 .topics(topics)
-                .policyDocument(new HashMap<>())
+                .policyDocument(null)
                 .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel> builder()


### PR DESCRIPTION
*Description of changes:*
For backwards compatibility, add String type to PolicyDocument. 

*Tests:*
- Add new unit tests.
- Add resource to Registry in the personal account and create template with String PolicyDocument

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
