### PR TITLE
Fix Topic and TopicPolicy resource type

### DIFF
--- a/aws-sns-topicinlinepolicy/aws-sns-topicinlinepolicy.json
+++ b/aws-sns-topicinlinepolicy/aws-sns-topicinlinepolicy.json
@@ -52,9 +52,6 @@
                 "sns:SetTopicAttributes",
                 "sns:GetTopicAttributes"
             ]
-        },
-        "list": {
-            "permissions": []
         }
     }
 }

--- a/aws-sns-topicpolicy/aws-sns-topicpolicy.json
+++ b/aws-sns-topicpolicy/aws-sns-topicpolicy.json
@@ -52,16 +52,10 @@
                 "sns:SetTopicAttributes"
             ]
         },
-        "read": {
-            "permissions": []
-        },
         "delete": {
             "permissions": [
                 "sns:SetTopicAttributes"
             ]
-        },
-        "list": {
-            "permissions": []
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
Fix Topic and TopicPolicy resource type

*Description of changes:*
Remove read and list from TopicPolicy and TopicInlinePolicy handler permission. So resource type will change from `FULLY_MUTABLE` to `NON_PROVISIONABLE`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
